### PR TITLE
Drive detail

### DIFF
--- a/lib/drives/forms/create_drive_form.dart
+++ b/lib/drives/forms/create_drive_form.dart
@@ -104,17 +104,18 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
           startTime: _selectedDate,
           endTime: endTime,
         );
-        //add Drive to database an Navigate to DriveDetailPage
-        await supabaseClient
-            .from('drives')
-            .insert(drive.toJson())
-            .then(((value) => Navigator.pushReplacement<void, void>(
-                  context,
-                  MaterialPageRoute<void>(
-                    //todo: call DriveDetailPage with id of created drive when implemented
-                    builder: (BuildContext context) => const DriveDetailPage(),
-                  ),
-                )));
+
+        await supabaseClient.from('drives').insert(drive.toJson()).select<Map<String, dynamic>>().single().then(
+          (data) {
+            Drive drive = Drive.fromJson(data);
+            Navigator.pushReplacement<void, void>(
+              context,
+              MaterialPageRoute<void>(
+                builder: (BuildContext context) => DriveDetailPage.fromDrive(drive: drive),
+              ),
+            );
+          },
+        );
       } on AuthException {
         //todo: change error message when login is implemented
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(

--- a/lib/drives/forms/create_drive_form.dart
+++ b/lib/drives/forms/create_drive_form.dart
@@ -111,7 +111,7 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
             Navigator.pushReplacement<void, void>(
               context,
               MaterialPageRoute<void>(
-                builder: (BuildContext context) => DriveDetailPage.fromDrive(drive: drive),
+                builder: (BuildContext context) => DriveDetailPage.fromDrive(drive),
               ),
             );
           },

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_app/rides/models/ride.dart';
 import 'package:flutter_app/util/supabase.dart';
 
 import '../../util/model.dart';
@@ -11,6 +12,8 @@ class Drive extends Model {
   final int seats;
   final int driverId;
 
+  final List<Ride>? rides;
+
   Drive({
     super.id,
     super.createdAt,
@@ -20,6 +23,7 @@ class Drive extends Model {
     required this.endTime,
     required this.seats,
     required this.driverId,
+    this.rides,
   });
 
   @override
@@ -33,6 +37,7 @@ class Drive extends Model {
       endTime: DateTime.parse(json['end_time']),
       seats: json['seats'],
       driverId: json['driver_id'],
+      rides: json.containsKey('rides') ? Ride.fromJsonList(json['rides']) : null,
     );
   }
 
@@ -70,5 +75,32 @@ class Drive extends Model {
       }
     }
     return null;
+  }
+
+  int? getMaxUsedSeats() {
+    if (rides == null) return null;
+
+    Set<DateTime> times = rides!.map((ride) => [ride.startTime, ride.endTime]).expand((x) => x).toSet();
+
+    int maxUsedSeats = 0;
+    for (DateTime time in times) {
+      int usedSeats = 0;
+      for (Ride ride in rides!) {
+        final startTimeBeforeOrEqual = ride.startTime.isBefore(time) || ride.startTime.isAtSameMomentAs(time);
+        final endTimeAfter = ride.endTime.isAfter(time);
+        if (startTimeBeforeOrEqual && endTimeAfter) {
+          usedSeats += ride.seats;
+        }
+      }
+
+      if (usedSeats > maxUsedSeats) {
+        maxUsedSeats = usedSeats;
+      }
+    }
+    return maxUsedSeats;
+  }
+
+  void cancel() {
+    // TODO: implement cancel
   }
 }

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/drives/models/drive.dart';
+import 'package:flutter_app/rides/models/ride.dart';
+import 'package:flutter_app/settings/models/profile.dart';
+import 'package:flutter_app/util/custom_timeline_theme.dart';
 import 'package:flutter_app/util/supabase.dart';
 import 'package:intl/intl.dart';
 import 'package:timelines/timelines.dart';
@@ -9,7 +12,7 @@ class DriveDetailPage extends StatefulWidget {
   final Drive? drive;
 
   const DriveDetailPage({super.key, required this.id}) : drive = null;
-  DriveDetailPage.fromDrive({super.key, required this.drive}) : id = drive!.id!;
+  DriveDetailPage.fromDrive(this.drive, {super.key}) : id = drive!.id!;
 
   @override
   State<DriveDetailPage> createState() => _DriveDetailPageState();
@@ -17,6 +20,7 @@ class DriveDetailPage extends StatefulWidget {
 
 class _DriveDetailPageState extends State<DriveDetailPage> {
   Drive? _drive;
+  List<Ride>? _rides;
 
   @override
   void initState() {
@@ -36,13 +40,143 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
         .eq('id', widget.id)
         .single();
 
+    List<dynamic> ridesData = await supabaseClient.from('rides').select('''
+          *,
+          rider:rider_id (*)
+        ''').eq('drive_id', widget.id).order('start_time', ascending: true);
+
     setState(() {
       _drive = Drive.fromJson(data);
+      _rides = Ride.fromJsonList(ridesData);
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    TimelineTile startTimelineTile = TimelineTile(
+      contents: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+                "${DateFormat.Hm().format(_drive!.startTime)} ${_drive!.start}"),
+            const Icon(
+              Icons.chat,
+              color: Colors.black,
+              size: 36.0,
+            ),
+          ],
+        ),
+      ),
+      node: const TimelineNode(
+        indicator: OutlinedDotIndicator(),
+        endConnector: SolidLineConnector(),
+      ),
+    );
+
+    TimelineTile stopTimelineTile = TimelineTile(
+      contents: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text("${DateFormat.Hm().format(_drive!.endTime)} ${_drive!.end}"),
+            Text('3/${_drive!.seats} Seats'),
+          ],
+        ),
+      ),
+      node: const TimelineNode(
+        indicator: OutlinedDotIndicator(),
+        startConnector: SolidLineConnector(),
+      ),
+    );
+
+    List<Widget> widgets = [
+      FixedTimeline(
+        theme: CustomTimelineTheme.of(context),
+        children: [startTimelineTile, stopTimelineTile],
+      ),
+    ];
+
+    if (_rides != null) {
+      List<Stop> stops = [];
+      for (Ride ride in _rides!) {
+        bool startSaved = false;
+        bool endSaved = false;
+        for (Stop stop in stops) {
+          if (ride.start == stop.place && stop.isStart) {
+            startSaved = true;
+            stop.profiles.add(ride.rider!);
+          } else if (ride.end == stop.place && !stop.isStart) {
+            endSaved = true;
+            stop.profiles.add(ride.rider!);
+          }
+        }
+
+        if (!startSaved) {
+          stops.add(Stop(
+            profiles: [ride.rider!],
+            place: ride.start,
+            time: ride.startTime,
+            isStart: true,
+            seats: ride.seats,
+          ));
+        }
+
+        if (!endSaved) {
+          stops.add(Stop(
+            profiles: [ride.rider!],
+            place: ride.end,
+            time: ride.endTime,
+            isStart: false,
+            seats: ride.seats,
+          ));
+        }
+      }
+      stops.sort((a, b) {
+        int aBeforeB = a.time.compareTo(b.time);
+        if (aBeforeB != 0) return aBeforeB;
+        return a.isStart ? 1 : -1;
+      });
+
+      List<TimelineTile> nodes = [startTimelineTile];
+      nodes.addAll(
+        stops.map(
+          (stop) => TimelineTile(
+            contents: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text("${DateFormat.Hm().format(stop.time)} ${stop.place}"),
+                  const Icon(
+                    Icons.chat,
+                    color: Colors.black,
+                    size: 36.0,
+                  ),
+                ],
+              ),
+            ),
+            node: const TimelineNode(
+              indicator: OutlinedDotIndicator(),
+              startConnector: SolidLineConnector(),
+              endConnector: SolidLineConnector(),
+            ),
+          ),
+        ),
+      );
+      nodes.add(stopTimelineTile);
+
+      Widget stopsTimeline = FixedTimeline(
+        theme: CustomTimelineTheme.of(context),
+        children: nodes,
+      );
+
+      widgets.add(const Divider());
+      widgets.add(stopsTimeline);
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Drive Detail'),
@@ -53,54 +187,27 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               onRefresh: loadDrive,
               child: SingleChildScrollView(
                 physics: const AlwaysScrollableScrollPhysics(),
-                child: FixedTimeline(
-                  theme: TimelineTheme.of(context).copyWith(
-                    nodePosition: 0.05,
-                    color: Colors.black,
-                  ),
-                  children: [
-                    TimelineTile(
-                      contents: Padding(
-                        padding: const EdgeInsets.all(16.0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                                "${DateFormat.Hm().format(_drive!.startTime)} ${_drive!.start}"),
-                            const Icon(
-                              Icons.chat,
-                              color: Colors.black,
-                              size: 36.0,
-                            ),
-                          ],
-                        ),
-                      ),
-                      node: const TimelineNode(
-                        indicator: OutlinedDotIndicator(),
-                        endConnector: SolidLineConnector(),
-                      ),
-                    ),
-                    TimelineTile(
-                      contents: Padding(
-                        padding: const EdgeInsets.all(16.0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                                "${DateFormat.Hm().format(_drive!.endTime)} ${_drive!.end}"),
-                            Text('3/${_drive!.seats} Seats'),
-                          ],
-                        ),
-                      ),
-                      node: const TimelineNode(
-                        indicator: OutlinedDotIndicator(),
-                        startConnector: SolidLineConnector(),
-                      ),
-                    ),
-                  ],
+                child: Column(
+                  children: widgets,
                 ),
               ),
             ),
     );
   }
+}
+
+class Stop {
+  List<Profile> profiles;
+  final String place;
+  final DateTime time;
+  final bool isStart;
+  final int seats;
+
+  Stop({
+    required this.profiles,
+    required this.place,
+    required this.time,
+    required this.isStart,
+    required this.seats,
+  });
 }

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -1,22 +1,106 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/drives/models/drive.dart';
+import 'package:flutter_app/util/supabase.dart';
+import 'package:intl/intl.dart';
+import 'package:timelines/timelines.dart';
 
 class DriveDetailPage extends StatefulWidget {
-  const DriveDetailPage({super.key});
+  final int id;
+  final Drive? drive;
+
+  const DriveDetailPage({super.key, required this.id}) : drive = null;
+  DriveDetailPage.fromDrive({super.key, required this.drive}) : id = drive!.id!;
 
   @override
   State<DriveDetailPage> createState() => _DriveDetailPageState();
 }
 
 class _DriveDetailPageState extends State<DriveDetailPage> {
+  Drive? _drive;
+
+  @override
+  void initState() {
+    super.initState();
+
+    setState(() {
+      _drive = widget.drive;
+    });
+
+    loadDrive();
+  }
+
+  Future<void> loadDrive() async {
+    Map<String, dynamic> data = await supabaseClient
+        .from('drives')
+        .select()
+        .eq('id', widget.id)
+        .single();
+
+    setState(() {
+      _drive = Drive.fromJson(data);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Drive Detail'),
       ),
-      body: const Center(
-        child: Text('Drive Detail'),
-      ),
+      body: _drive == null
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: loadDrive,
+              child: SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: FixedTimeline(
+                  theme: TimelineTheme.of(context).copyWith(
+                    nodePosition: 0.05,
+                    color: Colors.black,
+                  ),
+                  children: [
+                    TimelineTile(
+                      contents: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                                "${DateFormat.Hm().format(_drive!.startTime)} ${_drive!.start}"),
+                            const Icon(
+                              Icons.chat,
+                              color: Colors.black,
+                              size: 36.0,
+                            ),
+                          ],
+                        ),
+                      ),
+                      node: const TimelineNode(
+                        indicator: OutlinedDotIndicator(),
+                        endConnector: SolidLineConnector(),
+                      ),
+                    ),
+                    TimelineTile(
+                      contents: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                                "${DateFormat.Hm().format(_drive!.endTime)} ${_drive!.end}"),
+                            Text('3/${_drive!.seats} Seats'),
+                          ],
+                        ),
+                      ),
+                      node: const TimelineNode(
+                        indicator: OutlinedDotIndicator(),
+                        startConnector: SolidLineConnector(),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
     );
   }
 }

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -89,12 +89,10 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
       ),
     );
 
-    List<Widget> widgets = [
-      FixedTimeline(
-        theme: CustomTimelineTheme.of(context),
-        children: [startTimelineTile, stopTimelineTile],
-      ),
-    ];
+    Widget shortTimeline = FixedTimeline(
+      theme: CustomTimelineTheme.of(context),
+      children: [startTimelineTile, stopTimelineTile],
+    );
 
     List<Stop> stops = [];
     if (_drive != null) {
@@ -149,34 +147,6 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
         return a.status.index.compareTo(b.status.index);
       });
 
-      // nodes.addAll(
-      //   stops.map(
-      //     (stop) => TimelineTile(
-      //       contents: Padding(
-      //         padding: const EdgeInsets.all(16.0),
-      //         child: Row(
-      //           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      //           children: [
-      //             Text("${DateFormat.Hm().format(stop.time)} ${stop.place}"),
-      //             const Icon(
-      //               Icons.chat,
-      //               color: Colors.black,
-      //               size: 36.0,
-      //             ),
-      //           ],
-      //         ),
-      //       ),
-      //       node: TimelineNode(
-      //         overlap: true,
-      //         indicator: OutlinedDotIndicator(),
-      //         startConnector: Random().nextBool()
-      //             ? SolidLineConnector()
-      //             : DashedLineConnector(),
-      //         endConnector: SolidLineConnector(),
-      //       ),
-      //     ),
-      //   ),
-      // );
       if (_drive != null) {
         stops.add(Stop(
           profiles: [],
@@ -186,16 +156,12 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
           seats: _drive!.seats,
         ));
       }
-
-      widgets.add(const Divider(
-        thickness: 1,
-      ));
     }
 
-    Timeline timeline = Timeline.tileBuilder(
+    Widget timeline = FixedTimeline.tileBuilder(
       theme: CustomTimelineTheme.of(context),
-      padding: const EdgeInsets.only(top: 20.0),
       builder: TimelineTileBuilder.connected(
+        connectionDirection: ConnectionDirection.after,
         indicatorBuilder: (context, index) {
           final stop = stops[index];
           return OutlinedDotIndicator(
@@ -219,50 +185,149 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
         },
         contentsBuilder: (context, index) {
           final stop = stops[index];
-          return SizedBox(
-            height: 60.0,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text("${DateFormat.Hm().format(stop.time)} ${stop.place}"),
-                const Icon(
-                  Icons.chat,
-                  color: Colors.black,
-                  size: 36.0,
-                ),
-              ],
-            ),
-          );
+          return Padding(
+              padding: const EdgeInsets.only(left: 8.0),
+              child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: List.generate(1 + stop.profiles.length, (index) {
+                    if (index == 0) {
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              "${DateFormat.Hm().format(stop.time)} ",
+                              style: DefaultTextStyle.of(context)
+                                  .style
+                                  .copyWith(fontWeight: FontWeight.w700),
+                            ),
+                            Text(stop.place),
+                          ],
+                        ),
+                      );
+                    }
+                    const startIcon =
+                        Icon(Icons.north_east, color: Colors.green);
+                    const endIcon = Icon(Icons.south_west, color: Colors.red);
+                    return Container(
+                        decoration: const BoxDecoration(
+                            color: Colors.grey,
+                            borderRadius:
+                                BorderRadius.all(Radius.circular(3.0))),
+                        child: Material(
+                            color: Colors.transparent,
+                            child: InkWell(
+                                onTap: () => print("Hey"),
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 5.0, vertical: 5.0),
+                                  child: Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      stop.status == StopStatus.rideStart
+                                          ? startIcon
+                                          : endIcon,
+                                      Row(
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: [
+                                            CircleAvatar(
+                                                child: Text(stop
+                                                    .profiles[index - 1]
+                                                    .username[0])),
+                                            SizedBox(width: 5),
+                                            Text(stop
+                                                .profiles[index - 1].username)
+                                          ]),
+                                      const Icon(
+                                        Icons.chat,
+                                        color: Colors.black,
+                                        size: 36.0,
+                                      ),
+                                    ],
+                                  ),
+                                ))));
+                  })));
+        },
+        itemExtentBuilder: (context, index) {
+          return (stops[index].profiles.length + 1) * 50.0;
         },
         itemCount: stops.length,
       ),
     );
 
+    List<Widget> widgets = [
+      shortTimeline,
+      Divider(thickness: 1),
+      timeline,
+    ];
+
+    Widget ridersColumn = Container();
+    if (_rides != null) {
+      List<Profile> riders = [];
+      for (Ride ride in _rides!) {
+        if (ride.rider != null && !riders.contains(ride.rider)) {
+          riders.add(ride.rider!);
+        }
+      }
+      ridersColumn = Column(
+        children: List.generate(
+            riders.length,
+            (index) => InkWell(
+                onTap: () => print("Hey"),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 5.0, vertical: 5.0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Row(mainAxisSize: MainAxisSize.min, children: [
+                        CircleAvatar(child: Text(riders[index].username[0])),
+                        SizedBox(width: 5),
+                        Text(riders[index].username)
+                      ]),
+                      const Icon(
+                        Icons.chat,
+                        color: Colors.black,
+                        size: 36.0,
+                      ),
+                    ],
+                  ),
+                ))),
+      );
+      widgets.add(const Divider(
+        thickness: 1,
+      ));
+      widgets.add(ridersColumn);
+    }
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Drive Detail'),
-        actions: <Widget>[
-          IconButton(
-            onPressed: () {},
-            icon: const Icon(Icons.chat),
-          )
-        ],
-      ),
-      body: _drive == null
-          ? const Center(child: CircularProgressIndicator())
-          : Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                child: Column(
-                  children: [
-                    startTimelineTile,
-                    Divider(thickness: 1),
-                    Row(children: [timeline]),
-                  ],
+        appBar: AppBar(
+          title: const Text('Drive Detail'),
+          actions: <Widget>[
+            IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.chat),
+            )
+          ],
+        ),
+        body: _drive == null
+            ? const Center(child: CircularProgressIndicator())
+            : RefreshIndicator(
+                onRefresh: loadDrive,
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: widgets,
+                    ),
+                  ),
                 ),
-              ),
-            ),
-    );
+              ));
   }
 }
 

--- a/lib/drives/pages/drives_page.dart
+++ b/lib/drives/pages/drives_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/drives/models/drive.dart';
 import 'package:flutter_app/drives/pages/create_drive_page.dart';
+import 'package:flutter_app/drives/pages/drive_detail_page.dart';
+import 'package:flutter_app/util/supabase.dart';
 
 class DrivesPage extends StatefulWidget {
   const DrivesPage({super.key});
@@ -19,14 +22,22 @@ class _DrivesPageState extends State<DrivesPage> {
         child: Text('Drives'),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(builder: (context) => const CreateDrivePage()),
-          );
-        },
+        onPressed: onPressed,
         backgroundColor: Theme.of(context).colorScheme.primary,
         child: const Icon(Icons.add),
       ),
     );
+  }
+
+  void onPressed() async {
+    Map<String, dynamic> data =
+        await supabaseClient.from('drives').select().limit(1).single();
+    Drive drive = Drive.fromJson(data);
+    if (mounted) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+            builder: (context) => DriveDetailPage.fromDrive(drive)),
+      );
+    }
   }
 }

--- a/lib/drives/pages/drives_page.dart
+++ b/lib/drives/pages/drives_page.dart
@@ -30,13 +30,11 @@ class _DrivesPageState extends State<DrivesPage> {
   }
 
   void onPressed() async {
-    Map<String, dynamic> data =
-        await supabaseClient.from('drives').select().limit(1).single();
+    Map<String, dynamic> data = await supabaseClient.from('drives').select().eq('id', 33).limit(1).single();
     Drive drive = Drive.fromJson(data);
     if (mounted) {
       Navigator.of(context).push(
-        MaterialPageRoute(
-            builder: (context) => DriveDetailPage.fromDrive(drive)),
+        MaterialPageRoute(builder: (context) => DriveDetailPage.fromDrive(drive)),
       );
     }
   }

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_app/settings/models/profile.dart';
 import 'package:flutter_app/util/supabase.dart';
 
 import '../../util/model.dart';
@@ -14,6 +15,7 @@ class Ride extends Model {
 
   final int driveId;
   final int riderId;
+  final Profile? rider;
 
   Ride({
     super.id,
@@ -27,6 +29,7 @@ class Ride extends Model {
     required this.approved,
     required this.driveId,
     required this.riderId,
+    this.rider,
   });
 
   @override
@@ -43,6 +46,7 @@ class Ride extends Model {
       approved: json['approved'],
       driveId: json['drive_id'],
       riderId: json['rider_id'],
+      rider: json.containsKey('rider') ? Profile.fromJson(json['rider']) : null,
     );
   }
 

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_app/settings/models/profile.dart';
+import 'package:flutter_app/account/models/profile.dart';
 import 'package:flutter_app/util/supabase.dart';
 
 import '../../util/model.dart';

--- a/lib/util/big_button.dart
+++ b/lib/util/big_button.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 
 class BigButton extends StatelessWidget {
   final String text;
+  final Color? color;
   final Function()? onPressed;
-  const BigButton({super.key, required this.text, this.onPressed});
+  const BigButton({super.key, required this.text, this.onPressed, this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -12,7 +13,7 @@ class BigButton extends StatelessWidget {
       height: 53,
       child: MaterialButton(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(100)),
-        color: Theme.of(context).colorScheme.primary,
+        color: color ?? Theme.of(context).colorScheme.primary,
         onPressed: onPressed,
         child: Text(
           text,

--- a/lib/util/custom_timeline_theme.dart
+++ b/lib/util/custom_timeline_theme.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:timelines/timelines.dart';
+
+class CustomTimelineTheme {
+  static TimelineThemeData of(BuildContext context) {
+    return TimelineTheme.of(context).copyWith(
+      nodePosition: 0.05,
+      color: Colors.black,
+    );
+  }
+}

--- a/lib/util/custom_timeline_theme.dart
+++ b/lib/util/custom_timeline_theme.dart
@@ -4,11 +4,46 @@ import 'package:timelines/timelines.dart';
 class CustomTimelineTheme {
   static TimelineThemeData of(BuildContext context) {
     return TimelineTheme.of(context).copyWith(
-      nodePosition: 0.05,
+      nodePosition: 0,
       nodeItemOverlap: true,
-      connectorTheme:
-          const ConnectorThemeData(color: Color(0xffe6e7e9), thickness: 15.0),
-      color: Colors.black,
+      connectorTheme: ConnectorThemeData(color: Theme.of(context).colorScheme.secondary, thickness: 5.0),
+      indicatorTheme: IndicatorThemeData(
+        color: Theme.of(context).colorScheme.onSurface,
+        size: 15.0,
+      ),
+    );
+  }
+}
+
+class CustomTimelineThemeForBuilder {
+  static TimelineThemeData of(BuildContext context) {
+    return CustomTimelineTheme.of(context).copyWith(
+      indicatorTheme: CustomTimelineTheme.of(context).indicatorTheme.copyWith(
+            position: 0.5,
+          ),
+    );
+  }
+}
+
+class CustomOutlinedDotIndicator extends StatelessWidget {
+  const CustomOutlinedDotIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedDotIndicator(
+      color: CustomTimelineTheme.of(context).indicatorTheme.color,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+    );
+  }
+}
+
+class CustomSolidLineConnector extends StatelessWidget {
+  const CustomSolidLineConnector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SolidLineConnector(
+      color: CustomTimelineTheme.of(context).connectorTheme.color,
     );
   }
 }

--- a/lib/util/custom_timeline_theme.dart
+++ b/lib/util/custom_timeline_theme.dart
@@ -5,6 +5,9 @@ class CustomTimelineTheme {
   static TimelineThemeData of(BuildContext context) {
     return TimelineTheme.of(context).copyWith(
       nodePosition: 0.05,
+      nodeItemOverlap: true,
+      connectorTheme:
+          const ConnectorThemeData(color: Color(0xffe6e7e9), thickness: 15.0),
       color: Colors.black,
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -406,6 +406,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.12"
+  timelines:
+    dependency: "direct main"
+    description:
+      name: timelines
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   flutter_dotenv: ^5.0.2
   progress_state_button: ^1.0.4
 
+  timelines: ^0.1.0
+
   # Internationalization
   intl: ^0.17.0
 


### PR DESCRIPTION
Add a detailed page for drives. It contains
- a small overview at the top,
- a detailed timeline which shows who enters and who leaves at every waypoint,
- a list of riders,
-  and a "Delete" button.

Note: There is a constructor DriveDetailPage.fromDrive, which enables us to load some details in advance and have them shown on the DriveDetailPage without pesky loading time.

Additionally, we made it possible for the ride and drive models to contain its riders and rides as proper objects and not just IDs. This can be used with supabase calls joining the respective tables as shown in the code. There is also a method in the drive model for determining the max number of seats in a drive.