### PR TITLE
A11y

### DIFF
--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -42,6 +42,12 @@ class _AccountPageState extends State<AccountPage> {
                   }),
             ),
           ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text("Ok"),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ],
         ),
       ),
     );
@@ -68,6 +74,12 @@ class _AccountPageState extends State<AccountPage> {
               ),
             ),
           ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text("Ok"),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/account/pages/help_page.dart
+++ b/lib/account/pages/help_page.dart
@@ -84,9 +84,12 @@ class _FAQCardState extends State<FAQCard> {
                         const Divider(
                           thickness: 1,
                         ),
-                        Text(
-                          widget.answer,
-                          textAlign: TextAlign.start,
+                        Semantics(
+                          liveRegion: true,
+                          child: Text(
+                            widget.answer,
+                            textAlign: TextAlign.start,
+                          ),
                         ),
                       ],
                     )

--- a/lib/drives/pages/create_drive_page.dart
+++ b/lib/drives/pages/create_drive_page.dart
@@ -198,26 +198,32 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Expanded(
-                  child: TextFormField(
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      labelText: S.of(context).formDate,
+                  child: Semantics(
+                    button: true,
+                    child: TextFormField(
+                      decoration: InputDecoration(
+                        border: const OutlineInputBorder(),
+                        labelText: S.of(context).formDate,
+                      ),
+                      readOnly: true,
+                      onTap: _showDatePicker,
+                      controller: _dateController,
                     ),
-                    readOnly: true,
-                    onTap: _showDatePicker,
-                    controller: _dateController,
                   ),
                 ),
                 Expanded(
-                  child: TextFormField(
-                    decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
-                      labelText: S.of(context).formTime,
+                  child: Semantics(
+                    button: true,
+                    child: TextFormField(
+                      decoration: InputDecoration(
+                        border: const OutlineInputBorder(),
+                        labelText: S.of(context).formTime,
+                      ),
+                      readOnly: true,
+                      onTap: _showTimePicker,
+                      controller: _timeController,
+                      validator: _timeValidator,
                     ),
-                    readOnly: true,
-                    onTap: _showTimePicker,
-                    controller: _timeController,
-                    validator: _timeValidator,
                   ),
                 ),
                 const SizedBox(width: 50),

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -218,6 +218,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               position: BadgePosition.topEnd(top: -12),
               child: const Icon(Icons.chat),
             ),
+            tooltip: 'Chat',
           ),
         ],
       ),
@@ -236,18 +237,20 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   List<Widget> buildCard(Waypoint stop) {
     List<Widget> list = [];
     list.add(
-      Padding(
-        padding: const EdgeInsets.only(bottom: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              localeManager.formatTime(stop.time),
-              style: DefaultTextStyle.of(context).style.copyWith(fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(width: 4.0),
-            Text(stop.place),
-          ],
+      MergeSemantics(
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                localeManager.formatTime(stop.time),
+                style: DefaultTextStyle.of(context).style.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(width: 4.0),
+              Text(stop.place),
+            ],
+          ),
         ),
       ),
     );
@@ -259,38 +262,45 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
       final icon = action.isStart ? startIcon : endIcon;
       final profile = action.profile;
 
-      Widget container = Container(
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-          borderRadius: const BorderRadius.all(Radius.circular(5.0)),
-        ),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: () {},
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 10.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  Expanded(
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: IconWidget(icon: icon, count: action.seats),
-                    ),
-                  ),
-                  ProfileWidget(profile, size: 15),
-                  Expanded(
-                    child: Align(
-                      alignment: Alignment.centerRight,
-                      child: Icon(
-                        Icons.chat,
-                        color: Theme.of(context).colorScheme.onSurface,
-                        size: 30.0,
+      Widget container = Semantics(
+        button: true,
+        label:
+            "${action.isStart ? "Pick up" : "Drop-off"} ${action.seats} people associated with ${action.profile.username}.",
+        excludeSemantics: true,
+        tooltip: "Open Chat",
+        child: Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
+            borderRadius: const BorderRadius.all(Radius.circular(5.0)),
+          ),
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () {},
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 10.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: IconWidget(icon: icon, count: action.seats),
                       ),
                     ),
-                  ),
-                ],
+                    ProfileWidget(profile, size: 15),
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: Icon(
+                          Icons.chat,
+                          color: Theme.of(context).colorScheme.onSurface,
+                          size: 30.0,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -249,6 +249,8 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               ),
               const SizedBox(width: 4.0),
               Text(stop.place),
+              if (stop.place == _drive!.start) Semantics(label: 'Start of drive'),
+              if (stop.place == _drive!.end) Semantics(label: 'End of drive'),
             ],
           ),
         ),

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -218,7 +218,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               position: BadgePosition.topEnd(top: -12),
               child: const Icon(Icons.chat),
             ),
-            tooltip: 'Chat',
+            tooltip: S.of(context).openChat,
           ),
         ],
       ),
@@ -249,8 +249,8 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               ),
               const SizedBox(width: 4.0),
               Text(stop.place),
-              if (stop.place == _drive!.start) Semantics(label: 'Start of drive'),
-              if (stop.place == _drive!.end) Semantics(label: 'End of drive'),
+              if (stop.place == _drive!.start) Semantics(label: S.of(context).pageDriveDetailLabelStartDrive),
+              if (stop.place == _drive!.end) Semantics(label: S.of(context).pageDriveDetailLabelEndDrive),
             ],
           ),
         ),
@@ -266,10 +266,11 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
       Widget container = Semantics(
         button: true,
-        label:
-            "${action.isStart ? "Pick up" : "Drop-off"} ${action.seats} people associated with ${action.profile.username}.",
+        label: action.isStart
+            ? S.of(context).pageDriveDetailLabelPickup(action.seats, action.profile.username)
+            : S.of(context).pageDriveDetailLabelDropoff(action.seats, action.profile.username),
         excludeSemantics: true,
-        tooltip: "Open Chat",
+        tooltip: S.of(context).openChat,
         child: Container(
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),

--- a/lib/drives/pages/drives_page.dart
+++ b/lib/drives/pages/drives_page.dart
@@ -36,7 +36,7 @@ class _DrivesPageState extends State<DrivesPage> {
       _drives,
       (drive) => DriveCard(drive),
       FloatingActionButton(
-        tooltip: 'Offer ride',
+        tooltip: S.of(context).pageDrivesTooltipOfferRide,
         onPressed: onPressed,
         backgroundColor: Theme.of(context).colorScheme.primary,
         child: const Icon(Icons.add),

--- a/lib/drives/pages/drives_page.dart
+++ b/lib/drives/pages/drives_page.dart
@@ -36,6 +36,7 @@ class _DrivesPageState extends State<DrivesPage> {
       _drives,
       (drive) => DriveCard(drive),
       FloatingActionButton(
+        tooltip: 'Offer ride',
         onPressed: onPressed,
         backgroundColor: Theme.of(context).colorScheme.primary,
         child: const Icon(Icons.add),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -5,13 +5,15 @@
   "more": "Mehr",
   "yes": "Ja",
   "no": "Nein",
+  "approve": "Annehmen",
+  "reject": "Ablehnen",
   "failureSnackBar": "Es ist ein Fehler aufgetreten.",
 
   "riders": "Mitfahrer",
   "seats": "Plätze",
   "seatsCount": "{count, plural, =1{{count} Platz}, other{{count} Plätze}}",
-  "labelXOfYseats": "{seats, plural, =1{Einer}, other{{seats}}} von {maxSeats} Sitzen",
-  "labelUnknownSeats": "Unbekannte Anzahl von {maxSeats} Sitzen",
+  "labelXOfYseats": "{seats} von {maxSeats} Plätzen",
+  "labelUnknownSeats": "Unbekannte Anzahl von {maxSeats} Plätzen",
 
   "openChat": "Chat öffnen",
   "openDetails": "Details öffnen",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -10,6 +10,14 @@
   "riders": "Mitfahrer",
   "seats": "Plätze",
   "seatsCount": "{count, plural, =1{{count} Platz}, other{{count} Plätze}}",
+  "labelXOfYseats": "{seats, plural, =1{Einer}, other{{seats}}} von {maxSeats} Sitzen",
+  "labelUnknownSeats": "Unbekannte Anzahl von {maxSeats} Sitzen",
+
+  "openChat": "Chat öffnen",
+  "openDetails": "Details öffnen",
+  "seeProfile": "Profil ansehen",
+
+  "ratingBarSemantics": "{rating} Sterne",
 
   "authEmailLinkInvalid": "Email-Link ist ungültig oder abgelaufen.",
 
@@ -130,6 +138,10 @@
   "pageCreateDriveButtonCreate": "Erstellen",
 
   "pageDriveDetailTitle": "Fahrt Info",
+  "pageDriveDetailLabelStartDrive": "Start der Fahrt",
+  "pageDriveDetailLabelEndDrive": "Ende der Fahrt",
+  "pageDriveDetailLabelPickup": "{seats, plural, =1{{user} abholen}, other{{seats} Personen abholen, die mit {user} fahren}",
+  "pageDriveDetailLabelDropoff": "{seats, plural, =1{{user} absetzen}, other{{seats} Personen absetzen, die mit {user} fahren}",
   "pageDriveDetailButtonCancel": "Fahrt absagen",
   "pageDriveDetailCancelDialogTitle": "Absage bestätigen",
   "pageDriveDetailCancelDialogMessage": "Bist du sicher, dass du diese Fahrt absagen möchtest?",
@@ -137,6 +149,7 @@
   "pageDriveDetailBannerCancelled": "Du hast diese Fahrt abgesagt.",
 
   "pageDrivesTitle": "Fahrten",
+  "pageDrivesTooltipOfferRide": "Fahrt anbieten",
 
   "widgetTripBuilderTabUpcoming": "Zukünftig",
   "widgetTripBuilderTabPast": "Vergangen",
@@ -150,7 +163,10 @@
   "pageSearchSuggestionsButtonFilter": "Filter",
 
   "pageRidesTitle": "Mitfahrten",
+  "pageRidesTooltipSearchRide": "Fahrt suchen",
 
+  "pageRideDetailReviews" : "Bewertungen",
+  "pageRideDetailShowReviews" : "Bewertungen anzeigen",
   "pageRideDetailButtonRequest": "Mitfahrt anfragen",
   "pageRideDetailButtonCancel": "Mitfahrt absagen",
   "pageRideDetailButtonRate": "Fahrt bewerten",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,6 +5,8 @@
   "more": "More",
   "yes": "Yes",
   "no": "No",
+  "approve": "Approve",
+  "reject": "Reject",
   "failureSnackBar": "Something went wrong.",
 
   "riders": "Riders",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -15,6 +15,30 @@
       "count": {}
     }
   },
+  "labelXOfYseats": "{seats} of {maxSeats} seats",
+  "@labelXOfYseats": {
+    "placeholders": {
+      "seats": {},
+      "maxSeats": {}
+    }
+  },
+  "labelUnknownSeats": "unknown number of {maxSeats} seats",
+  "@labelUnknownSeats": {
+    "placeholders": {
+      "maxSeats": {}
+    }
+  },
+
+  "openChat": "Open Chat",
+  "openDetails": "Open Details",
+  "seeProfile": "See profile",
+
+  "ratingBarSemantics": "{rating} stars",
+  "@ratingBarSemantics": {
+    "placeholders": {
+      "rating": {}
+    }
+  },
 
   "authEmailLinkInvalid": "Email link is invalid or has expired.",
 
@@ -139,6 +163,22 @@
   "pageCreateDriveButtonCreate": "Create",
 
   "pageDriveDetailTitle": "Drive Detail",
+  "pageDriveDetailLabelStartDrive": "Start of drive",
+  "pageDriveDetailLabelEndDrive": "End of drive",
+  "pageDriveDetailLabelPickup": "{seats, plural, =1{Pick up {user}}, other{Pick up {seats} people associated with {user}}",
+  "@pageDriveDetailLabelPickup": {
+    "placeholders": {
+      "seats": {},
+      "user": {}
+    }
+  },
+  "pageDriveDetailLabelDropoff": "{seats, plural, =1{Drop off {user}}, other{Drop off {seats} people associated with {user}}",
+  "@pageDriveDetailLabelDropoff": {
+    "placeholders": {
+      "seats": {},
+      "user": {}
+    }
+  },
   "pageDriveDetailButtonCancel": "Cancel Drive",
   "pageDriveDetailCancelDialogTitle": "Confirm Cancellation",
   "pageDriveDetailCancelDialogMessage": "Are you sure you want to cancel this drive?",
@@ -146,6 +186,7 @@
   "pageDriveDetailBannerCancelled": "You have cancelled this drive.",
 
   "pageDrivesTitle": "Drives",
+  "pageDrivesTooltipOfferRide": "Offer ride",
 
   "widgetTripBuilderTabUpcoming": "Upcoming",
   "widgetTripBuilderTabPast": "Past",
@@ -169,7 +210,10 @@
   "pageSearchSuggestionsButtonFilter": "Filter",
 
   "pageRidesTitle": "Rides",
+  "pageRidesTooltipSearchRide": "Search ride",
 
+  "pageRideDetailReviews" : "Reviews",
+  "pageRideDetailShowReviews" : "Show reviews",
   "pageRideDetailButtonRequest": "Request Ride",
   "pageRideDetailButtonCancel": "Cancel Ride",
   "pageRideDetailButtonRate": "Rate Driver",

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -192,9 +192,9 @@ class _RideDetailPageState extends State<RideDetailPage> {
     AggregateReview aggregateReview = AggregateReview.fromReviews(reviews);
 
     return Semantics(
-      label: "Reviews",
+      label: S.of(context).pageRideDetailReviews,
       button: true,
-      tooltip: "Show reviews",
+      tooltip: S.of(context).pageRideDetailShowReviews,
       child: Stack(
         children: [
           Column(

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -191,120 +191,134 @@ class _RideDetailPageState extends State<RideDetailPage> {
     List<Review> reviews = driver.reviewsReceived!..sort((a, b) => a.compareTo(b));
     AggregateReview aggregateReview = AggregateReview.fromReviews(reviews);
 
-    return Stack(
-      children: [
-        Column(
-          children: [
-            Row(
-              children: [
-                Text(aggregateReview.rating.toStringAsFixed(1), style: const TextStyle(fontSize: 20)),
-                const SizedBox(width: 10),
-                CustomRatingBarIndicator(rating: aggregateReview.rating, size: CustomRatingBarSize.large),
-                Expanded(
-                  child: Text(
-                    S.of(context).pageReviewCount(reviews.length),
-                    style: TextStyle(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
-                    textAlign: TextAlign.right,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 10),
-            SizedBox(
-              width: double.infinity,
-              child: Wrap(
-                spacing: 5,
-                runSpacing: 5,
-                alignment: WrapAlignment.spaceBetween,
+    return Semantics(
+      label: "Reviews",
+      button: true,
+      tooltip: "Show reviews",
+      child: Stack(
+        children: [
+          Column(
+            children: [
+              Row(
                 children: [
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(S.of(context).reviewCategoryComfort),
-                      const SizedBox(width: 10),
-                      CustomRatingBarIndicator(rating: aggregateReview.comfortRating),
-                    ],
+                  ExcludeSemantics(
+                    child: Text(
+                      aggregateReview.rating.toStringAsFixed(1),
+                      style: const TextStyle(fontSize: 20),
+                    ),
                   ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(S.of(context).reviewCategorySafety),
-                      const SizedBox(width: 10),
-                      CustomRatingBarIndicator(rating: aggregateReview.safetyRating)
-                    ],
-                  ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(S.of(context).reviewCategoryReliability),
-                      const SizedBox(width: 10),
-                      CustomRatingBarIndicator(rating: aggregateReview.reliabilityRating)
-                    ],
-                  ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(S.of(context).reviewCategoryHospitality),
-                      const SizedBox(width: 10),
-                      CustomRatingBarIndicator(rating: aggregateReview.hospitalityRating)
-                    ],
+                  const SizedBox(width: 10),
+                  CustomRatingBarIndicator(rating: aggregateReview.rating, size: CustomRatingBarSize.large),
+                  Expanded(
+                    child: Text(
+                      S.of(context).pageReviewCount(reviews.length),
+                      style: TextStyle(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
+                      textAlign: TextAlign.right,
+                    ),
                   ),
                 ],
               ),
-            ),
-            if (reviews.isNotEmpty)
-              Column(
-                children: [
-                  const SizedBox(
-                    height: 10,
-                  ),
-                  ShaderMask(
-                    shaderCallback: (rect) => const LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [Colors.black, Colors.transparent],
-                    ).createShader(Rect.fromLTRB(0, 0, rect.width, rect.height)),
-                    blendMode: BlendMode.dstIn,
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxHeight: 200),
-                      child: ClipRect(
-                        child: SingleChildScrollView(
-                          physics: const NeverScrollableScrollPhysics(),
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: List.generate(
-                              min(reviews.length, 2),
-                              (index) => ReviewDetail(review: reviews[index]),
+              const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                child: Wrap(
+                  spacing: 5,
+                  runSpacing: 5,
+                  alignment: WrapAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(S.of(context).reviewCategoryComfort),
+                        const SizedBox(width: 10),
+                        CustomRatingBarIndicator(rating: aggregateReview.comfortRating),
+                      ],
+                    ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(S.of(context).reviewCategorySafety),
+                        const SizedBox(width: 10),
+                        CustomRatingBarIndicator(rating: aggregateReview.safetyRating)
+                      ],
+                    ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(S.of(context).reviewCategoryReliability),
+                        const SizedBox(width: 10),
+                        CustomRatingBarIndicator(rating: aggregateReview.reliabilityRating)
+                      ],
+                    ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(S.of(context).reviewCategoryHospitality),
+                        const SizedBox(width: 10),
+                        CustomRatingBarIndicator(rating: aggregateReview.hospitalityRating)
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              if (reviews.isNotEmpty)
+                ExcludeSemantics(
+                  child: Column(
+                    children: [
+                      const SizedBox(
+                        height: 10,
+                      ),
+                      ShaderMask(
+                        shaderCallback: (rect) => const LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [Colors.black, Colors.transparent],
+                        ).createShader(Rect.fromLTRB(0, 0, rect.width, rect.height)),
+                        blendMode: BlendMode.dstIn,
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxHeight: 200),
+                          child: ClipRect(
+                            child: SingleChildScrollView(
+                              physics: const NeverScrollableScrollPhysics(),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: List.generate(
+                                  min(reviews.length, 2),
+                                  (index) => ReviewDetail(review: reviews[index]),
+                                ),
+                              ),
                             ),
                           ),
                         ),
                       ),
-                    ),
+                    ],
                   ),
-                ],
-              )
-          ],
-        ),
-        if (reviews.isNotEmpty)
-          Positioned(
-            bottom: 2,
-            right: 2,
-            child: Text(
-              S.of(context).more,
-              style: TextStyle(color: Theme.of(context).primaryColor),
+                )
+            ],
+          ),
+          if (reviews.isNotEmpty)
+            Positioned(
+              bottom: 2,
+              right: 2,
+              child: ExcludeSemantics(
+                child: Text(
+                  S.of(context).more,
+                  style: TextStyle(color: Theme.of(context).primaryColor),
+                ),
+              ),
+            ),
+          Positioned.fill(
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: () {
+                  // TODO: Navigate to reviews page
+                },
+              ),
             ),
           ),
-        Positioned.fill(
-          child: Material(
-            color: Colors.transparent,
-            child: InkWell(
-              onTap: () {
-                // TODO: Navigate to reviews page
-              },
-            ),
-          ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -172,6 +172,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
           IconButton(
             onPressed: () {},
             icon: const Icon(Icons.chat),
+            tooltip: S.of(context).openChat,
           )
         ],
       ),

--- a/lib/rides/pages/rides_page.dart
+++ b/lib/rides/pages/rides_page.dart
@@ -38,6 +38,7 @@ class _RidesPageState extends State<RidesPage> {
       _rides, //trips
       (ride) => RideCard(ride),
       FloatingActionButton(
+        tooltip: 'Search ride',
         onPressed: () {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (context) => const SearchRidePage()),

--- a/lib/rides/pages/rides_page.dart
+++ b/lib/rides/pages/rides_page.dart
@@ -38,7 +38,7 @@ class _RidesPageState extends State<RidesPage> {
       _rides, //trips
       (ride) => RideCard(ride),
       FloatingActionButton(
-        tooltip: 'Search ride',
+        tooltip: S.of(context).pageRidesTooltipSearchRide,
         onPressed: () {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (context) => const SearchRidePage()),

--- a/lib/rides/pages/search_ride_page.dart
+++ b/lib/rides/pages/search_ride_page.dart
@@ -123,14 +123,17 @@ class _SearchRideFormState extends State<SearchRideForm> {
     _dateController.text = localeManager.formatDate(_selectedDate);
 
     return Expanded(
-      child: TextFormField(
-        decoration: InputDecoration(
-          border: const OutlineInputBorder(),
-          labelText: S.of(context).formDate,
+      child: Semantics(
+        button: true,
+        child: TextFormField(
+          decoration: InputDecoration(
+            border: const OutlineInputBorder(),
+            labelText: S.of(context).formDate,
+          ),
+          readOnly: true,
+          onTap: _showDatePicker,
+          controller: _dateController,
         ),
-        readOnly: true,
-        onTap: _showDatePicker,
-        controller: _dateController,
       ),
     );
   }
@@ -139,15 +142,18 @@ class _SearchRideFormState extends State<SearchRideForm> {
     _timeController.text = localeManager.formatTime(_selectedDate);
 
     return Expanded(
-      child: TextFormField(
-        decoration: InputDecoration(
-          border: const OutlineInputBorder(),
-          labelText: S.of(context).formTime,
+      child: Semantics(
+        button: true,
+        child: TextFormField(
+          decoration: InputDecoration(
+            border: const OutlineInputBorder(),
+            labelText: S.of(context).formTime,
+          ),
+          readOnly: true,
+          onTap: _showTimePicker,
+          controller: _timeController,
+          validator: _timeValidator,
         ),
-        readOnly: true,
-        onTap: _showTimePicker,
-        controller: _timeController,
-        validator: _timeValidator,
       ),
     );
   }

--- a/lib/rides/pages/search_suggestion_page.dart
+++ b/lib/rides/pages/search_suggestion_page.dart
@@ -175,35 +175,41 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
   Widget buildDatePicker() {
     _dateController.text = localeManager.formatDate(widget.date);
 
-    return TextFormField(
-      decoration: InputDecoration(
-        border: const OutlineInputBorder(),
-        labelText: S.of(context).formDate,
+    return Semantics(
+      button: true,
+      child: TextFormField(
+        decoration: InputDecoration(
+          border: const OutlineInputBorder(),
+          labelText: S.of(context).formDate,
+        ),
+        readOnly: true,
+        onTap: () {
+          _showDatePicker;
+          loadRides();
+        },
+        controller: _dateController,
       ),
-      readOnly: true,
-      onTap: () {
-        _showDatePicker;
-        loadRides();
-      },
-      controller: _dateController,
     );
   }
 
   Widget buildTimePicker() {
     _timeController.text = localeManager.formatTime(widget.date);
 
-    return TextFormField(
-      decoration: InputDecoration(
-        border: const OutlineInputBorder(),
-        labelText: S.of(context).formTime,
+    return Semantics(
+      button: true,
+      child: TextFormField(
+        decoration: InputDecoration(
+          border: const OutlineInputBorder(),
+          labelText: S.of(context).formTime,
+        ),
+        readOnly: true,
+        onTap: () {
+          _showTimePicker;
+          loadRides();
+        },
+        controller: _timeController,
+        validator: _timeValidator,
       ),
-      readOnly: true,
-      onTap: () {
-        _showTimePicker;
-        loadRides();
-      },
-      controller: _timeController,
-      validator: _timeValidator,
     );
   }
 

--- a/lib/util/loading_button.dart
+++ b/lib/util/loading_button.dart
@@ -53,13 +53,20 @@ class _LoadingButtonState extends State<LoadingButton> {
       onPressed: widget.onPressed,
       state: widget.state,
       textStyle: TextStyle(
-        color: widget.state == ButtonState.fail
-            ? Theme.of(context).colorScheme.onError
-            : widget.state == ButtonState.success
-                ? Theme.of(context).own().onSuccess
-                : Theme.of(context).colorScheme.onPrimary,
+        color: getTextColor(context),
         fontWeight: FontWeight.w500,
       ),
     );
+  }
+
+  Color getTextColor(BuildContext context) {
+    switch (widget.state) {
+      case ButtonState.fail:
+        return Theme.of(context).colorScheme.onError;
+      case ButtonState.success:
+        return Theme.of(context).own().onSuccess;
+      default:
+        return Theme.of(context).colorScheme.onPrimary;
+    }
   }
 }

--- a/lib/util/loading_button.dart
+++ b/lib/util/loading_button.dart
@@ -53,7 +53,11 @@ class _LoadingButtonState extends State<LoadingButton> {
       onPressed: widget.onPressed,
       state: widget.state,
       textStyle: TextStyle(
-        color: Theme.of(context).colorScheme.onPrimary,
+        color: widget.state == ButtonState.fail
+            ? Theme.of(context).colorScheme.onError
+            : widget.state == ButtonState.success
+                ? Theme.of(context).own().onSuccess
+                : Theme.of(context).colorScheme.onPrimary,
         fontWeight: FontWeight.w500,
       ),
     );

--- a/lib/util/profiles/profile_chip.dart
+++ b/lib/util/profiles/profile_chip.dart
@@ -12,16 +12,22 @@ class ProfileChip extends StatelessWidget {
     // TODO: Use profile picture
     return Padding(
       padding: const EdgeInsets.only(right: 8.0),
-      child: ActionChip(
-        avatar: CircleAvatar(
-          child: Text(profile.username[0]),
+      child: Semantics(
+        label: profile.username,
+        excludeSemantics: true,
+        button: true,
+        tooltip: "See profile",
+        child: ActionChip(
+          avatar: CircleAvatar(
+            child: Text(profile.username[0]),
+          ),
+          label: Text(profile.username),
+          labelPadding: const EdgeInsets.all(5),
+          padding: const EdgeInsets.all(5),
+          onPressed: () {
+            // TODO: Navigate to profile page
+          },
         ),
-        label: Text(profile.username),
-        labelPadding: const EdgeInsets.all(5),
-        padding: const EdgeInsets.all(5),
-        onPressed: () {
-          // TODO: Navigate to profile page
-        },
       ),
     );
   }

--- a/lib/util/profiles/profile_chip.dart
+++ b/lib/util/profiles/profile_chip.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class ProfileChip extends StatelessWidget {
   final Profile profile;
@@ -16,7 +17,7 @@ class ProfileChip extends StatelessWidget {
         label: profile.username,
         excludeSemantics: true,
         button: true,
-        tooltip: "See profile",
+        tooltip: S.of(context).seeProfile,
         child: ActionChip(
           avatar: CircleAvatar(
             child: Text(profile.username[0]),

--- a/lib/util/profiles/profile_widget.dart
+++ b/lib/util/profiles/profile_widget.dart
@@ -13,16 +13,22 @@ class ProfileWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        // TODO: Use profile picture
-        CircleAvatar(
-          minRadius: size,
-          child: Text(profile.username[0], style: TextStyle(fontSize: size)),
-        ),
-        const SizedBox(width: 5),
-        Text(profile.username, style: TextStyle(fontSize: size)),
-      ],
+    return Semantics(
+      label: profile.username,
+      excludeSemantics: true,
+      button: true,
+      tooltip: "See profile",
+      child: Row(
+        children: [
+          // TODO: Use profile picture
+          CircleAvatar(
+            minRadius: size,
+            child: Text(profile.username[0], style: TextStyle(fontSize: size)),
+          ),
+          const SizedBox(width: 5),
+          Text(profile.username, style: TextStyle(fontSize: size)),
+        ],
+      ),
     );
   }
 }

--- a/lib/util/profiles/profile_widget.dart
+++ b/lib/util/profiles/profile_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class ProfileWidget extends StatelessWidget {
   final Profile profile;
@@ -17,7 +18,7 @@ class ProfileWidget extends StatelessWidget {
       label: profile.username,
       excludeSemantics: true,
       button: true,
-      tooltip: "See profile",
+      tooltip: S.of(context).seeProfile,
       child: Row(
         children: [
           // TODO: Use profile picture

--- a/lib/util/profiles/reviews/custom_rating_bar_indicator.dart
+++ b/lib/util/profiles/reviews/custom_rating_bar_indicator.dart
@@ -14,15 +14,18 @@ class CustomRatingBarIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RatingBarIndicator(
-      rating: rating,
-      itemBuilder: (context, index) => const Icon(
-        Icons.star,
-        color: Colors.amber,
+    return Semantics(
+      label: "${rating.toStringAsFixed(1)} stars",
+      child: RatingBarIndicator(
+        rating: rating,
+        itemBuilder: (context, index) => const Icon(
+          Icons.star,
+          color: Colors.amber,
+        ),
+        itemCount: 5,
+        itemSize: size.itemSize,
+        direction: Axis.horizontal,
       ),
-      itemCount: 5,
-      itemSize: size.itemSize,
-      direction: Axis.horizontal,
     );
   }
 }

--- a/lib/util/profiles/reviews/custom_rating_bar_indicator.dart
+++ b/lib/util/profiles/reviews/custom_rating_bar_indicator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:motis_mitfahr_app/util/profiles/reviews/custom_rating_bar_size.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class CustomRatingBarIndicator extends StatelessWidget {
   final double rating;
@@ -15,7 +16,7 @@ class CustomRatingBarIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: "${rating.toStringAsFixed(1)} stars",
+      label: S.of(context).ratingBarSemantics(rating.toStringAsFixed(1)),
       child: RatingBarIndicator(
         rating: rating,
         itemBuilder: (context, index) => const Icon(

--- a/lib/util/search/address_search_field.dart
+++ b/lib/util/search/address_search_field.dart
@@ -39,31 +39,37 @@ class AddressSearchField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextFormField(
-      controller: controller,
-      decoration: InputDecoration(
-        border: const OutlineInputBorder(),
-        labelText: getLabelText(context),
-        hintText: getHintText(context),
-      ),
-      validator: (value) {
-        if (value == null || value.isEmpty) {
-          return getValidatorEmptyText(context);
-        }
-        return null;
-      },
-      onTap: () async {
-        final AddressSuggestion? addressSuggestion = await showSearch<AddressSuggestion?>(
-          context: context,
-          delegate: AddressSearchDelegate(),
-          query: controller.text,
-        );
+    return Semantics(
+      button: true,
+      label: getLabelText(context),
+      tooltip: getHintText(context),
+      excludeSemantics: true,
+      child: TextFormField(
+        controller: controller,
+        decoration: InputDecoration(
+          border: const OutlineInputBorder(),
+          labelText: getLabelText(context),
+          hintText: getHintText(context),
+        ),
+        validator: (value) {
+          if (value == null || value.isEmpty) {
+            return getValidatorEmptyText(context);
+          }
+          return null;
+        },
+        onTap: () async {
+          final AddressSuggestion? addressSuggestion = await showSearch<AddressSuggestion?>(
+            context: context,
+            delegate: AddressSearchDelegate(),
+            query: controller.text,
+          );
 
-        if (addressSuggestion != null) {
-          controller.text = addressSuggestion.name;
-          onSelected(addressSuggestion);
-        }
-      },
+          if (addressSuggestion != null) {
+            controller.text = addressSuggestion.name;
+            onSelected(addressSuggestion);
+          }
+        },
+      ),
     );
   }
 

--- a/lib/util/trip/drive_card.dart
+++ b/lib/util/trip/drive_card.dart
@@ -13,57 +13,61 @@ class DriveCard extends TripCard<Drive> {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: InkWell(
-        onTap: () => Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => DriveDetailPage.fromDrive(trip),
+    return Semantics(
+      button: true,
+      tooltip: "Open details",
+      child: Card(
+        child: InkWell(
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => DriveDetailPage.fromDrive(trip),
+            ),
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(12.0),
-              child: Text(localeManager.formatDate(trip.startTime)),
-            ),
-            const Divider(),
-            FixedTimeline(
-              theme: CustomTimelineTheme.of(context),
-              children: [
-                TimelineTile(
-                  contents: Padding(
-                    padding: const EdgeInsets.all(32.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text('${localeManager.formatTime(trip.startTime)}  ${trip.start}'),
-                      ],
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: Text(localeManager.formatDate(trip.startTime)),
+              ),
+              const Divider(),
+              FixedTimeline(
+                theme: CustomTimelineTheme.of(context),
+                children: [
+                  TimelineTile(
+                    contents: Padding(
+                      padding: const EdgeInsets.all(32.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text('${localeManager.formatTime(trip.startTime)}  ${trip.start}'),
+                        ],
+                      ),
+                    ),
+                    node: const TimelineNode(
+                      indicator: CustomOutlinedDotIndicator(),
+                      endConnector: CustomSolidLineConnector(),
                     ),
                   ),
-                  node: const TimelineNode(
-                    indicator: CustomOutlinedDotIndicator(),
-                    endConnector: CustomSolidLineConnector(),
-                  ),
-                ),
-                TimelineTile(
-                  contents: Padding(
-                    padding: const EdgeInsets.all(32.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text('${localeManager.formatTime(trip.endTime)}  ${trip.end}'),
-                      ],
+                  TimelineTile(
+                    contents: Padding(
+                      padding: const EdgeInsets.all(32.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text('${localeManager.formatTime(trip.endTime)}  ${trip.end}'),
+                        ],
+                      ),
                     ),
-                  ),
-                  node: const TimelineNode(
-                    indicator: CustomOutlinedDotIndicator(),
-                    startConnector: CustomSolidLineConnector(),
-                  ),
-                )
-              ],
-            ),
-          ],
+                    node: const TimelineNode(
+                      indicator: CustomOutlinedDotIndicator(),
+                      startConnector: CustomSolidLineConnector(),
+                    ),
+                  )
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/util/trip/drive_card.dart
+++ b/lib/util/trip/drive_card.dart
@@ -7,6 +7,7 @@ import '../../drives/pages/drive_detail_page.dart';
 import 'package:timelines/timelines.dart';
 
 import '../locale_manager.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class DriveCard extends TripCard<Drive> {
   const DriveCard(super.trip, {super.key});
@@ -16,7 +17,7 @@ class DriveCard extends TripCard<Drive> {
     return Card(
       child: Semantics(
         button: true,
-        tooltip: "Open details",
+        tooltip: S.of(context).openDetails,
         child: InkWell(
           onTap: () => Navigator.of(context).push(
             MaterialPageRoute(

--- a/lib/util/trip/drive_card.dart
+++ b/lib/util/trip/drive_card.dart
@@ -13,10 +13,10 @@ class DriveCard extends TripCard<Drive> {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      tooltip: "Open details",
-      child: Card(
+    return Card(
+      child: Semantics(
+        button: true,
+        tooltip: "Open details",
         child: InkWell(
           onTap: () => Navigator.of(context).push(
             MaterialPageRoute(

--- a/lib/util/trip/pending_ride_card.dart
+++ b/lib/util/trip/pending_ride_card.dart
@@ -94,6 +94,7 @@ class PendingRideCard extends TripCard<Ride> {
                     child: IconButton(
                       onPressed: (() => showApproveDialog(context)),
                       icon: const Icon(Icons.check_circle_outline, color: Colors.green, size: 50.0),
+                      tooltip: S.of(context).approve,
                     ),
                   ),
                   Padding(
@@ -101,6 +102,7 @@ class PendingRideCard extends TripCard<Ride> {
                     child: IconButton(
                       onPressed: (() => showRejectDialog(context)),
                       icon: const Icon(Icons.cancel_outlined, color: Colors.red, size: 50.0),
+                      tooltip: S.of(context).reject,
                     ),
                   )
                 ],

--- a/lib/util/trip/ride_card.dart
+++ b/lib/util/trip/ride_card.dart
@@ -12,13 +12,10 @@ class RideCard extends TripCard<Ride> {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label:
-          "From ${trip.start} to ${trip.end} starting at ${localeManager.formatTime(trip.startTime)}, arriving at ${localeManager.formatTime(trip.endTime)} on ${localeManager.formatDate(trip.startTime)}.",
-      tooltip: "Open details",
-      excludeSemantics: true,
-      child: Card(
+    return Card(
+      child: Semantics(
+        button: true,
+        tooltip: "Open details",
         child: InkWell(
           onTap: () => Navigator.of(context).push(
             MaterialPageRoute(

--- a/lib/util/trip/ride_card.dart
+++ b/lib/util/trip/ride_card.dart
@@ -12,67 +12,74 @@ class RideCard extends TripCard<Ride> {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: InkWell(
-        onTap: () => Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => RideDetailPage.fromRide(trip),
+    return Semantics(
+      button: true,
+      label:
+          "From ${trip.start} to ${trip.end} starting at ${localeManager.formatTime(trip.startTime)}, arriving at ${localeManager.formatTime(trip.endTime)} on ${localeManager.formatDate(trip.startTime)}.",
+      tooltip: "Open details",
+      excludeSemantics: true,
+      child: Card(
+        child: InkWell(
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => RideDetailPage.fromRide(trip),
+            ),
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(12.0),
-              child: Text(localeManager.formatDate(trip.startTime)),
-            ),
-            const Divider(),
-            FixedTimeline(
-              theme: CustomTimelineTheme.of(context),
-              children: [
-                TimelineTile(
-                  contents: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text('${localeManager.formatTime(trip.startTime)}  ${trip.start}'),
-                      ],
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: Text(localeManager.formatDate(trip.startTime)),
+              ),
+              const Divider(),
+              FixedTimeline(
+                theme: CustomTimelineTheme.of(context),
+                children: [
+                  TimelineTile(
+                    contents: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text('${localeManager.formatTime(trip.startTime)}  ${trip.start}'),
+                        ],
+                      ),
+                    ),
+                    node: const TimelineNode(
+                      indicator: CustomOutlinedDotIndicator(),
+                      endConnector: CustomSolidLineConnector(),
                     ),
                   ),
-                  node: const TimelineNode(
-                    indicator: CustomOutlinedDotIndicator(),
-                    endConnector: CustomSolidLineConnector(),
-                  ),
-                ),
-                TimelineTile(
-                  contents: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text('${localeManager.formatTime(trip.endTime)}  ${trip.end}'),
-                      ],
+                  TimelineTile(
+                    contents: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text('${localeManager.formatTime(trip.endTime)}  ${trip.end}'),
+                        ],
+                      ),
                     ),
-                  ),
-                  node: const TimelineNode(
-                    indicator: CustomOutlinedDotIndicator(),
-                    startConnector: CustomSolidLineConnector(),
-                  ),
-                )
-              ],
-            ),
-            const Divider(),
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: const [
-                  Text('Max'),
+                    node: const TimelineNode(
+                      indicator: CustomOutlinedDotIndicator(),
+                      startConnector: CustomSolidLineConnector(),
+                    ),
+                  )
                 ],
               ),
-            ),
-          ],
+              const Divider(),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: const [
+                    Text('Max'),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/util/trip/ride_card.dart
+++ b/lib/util/trip/ride_card.dart
@@ -4,6 +4,7 @@ import 'package:motis_mitfahr_app/util/custom_timeline_theme.dart';
 import 'package:motis_mitfahr_app/util/locale_manager.dart';
 import 'package:motis_mitfahr_app/util/trip/trip_card.dart';
 import 'package:timelines/timelines.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../rides/pages/ride_detail_page.dart';
 
@@ -15,7 +16,7 @@ class RideCard extends TripCard<Ride> {
     return Card(
       child: Semantics(
         button: true,
-        tooltip: "Open details",
+        tooltip: S.of(context).openDetails,
         child: InkWell(
           onTap: () => Navigator.of(context).push(
             MaterialPageRoute(

--- a/lib/util/trip/search_card.dart
+++ b/lib/util/trip/search_card.dart
@@ -4,6 +4,8 @@ import 'package:motis_mitfahr_app/rides/models/ride.dart';
 import 'package:motis_mitfahr_app/rides/pages/ride_detail_page.dart';
 import 'package:motis_mitfahr_app/util/custom_timeline_theme.dart';
 import 'package:motis_mitfahr_app/util/locale_manager.dart';
+import 'package:motis_mitfahr_app/util/profiles/profile_widget.dart';
+import 'package:motis_mitfahr_app/util/profiles/reviews/custom_rating_bar_indicator.dart';
 import 'package:motis_mitfahr_app/util/trip/trip_card.dart';
 import 'package:timelines/timelines.dart';
 
@@ -58,30 +60,6 @@ class SearchCard extends TripCard<Ride> {
     );
   }
 
-  Widget buildProfile(driver) {
-    return Row(
-      children: [
-        CircleAvatar(
-          child: Text(driver.username[0]),
-        ),
-        const SizedBox(width: 5),
-        Text(driver.username),
-      ],
-    );
-  }
-
-  Widget buildRanking() {
-    return Row(
-      children: const [
-        Text("3"),
-        Icon(
-          Icons.star,
-          color: Colors.amberAccent,
-        ),
-      ],
-    );
-  }
-
   Widget buildCardInfo(context, driver) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -101,8 +79,8 @@ class SearchCard extends TripCard<Ride> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              buildProfile(driver),
-              buildRanking(),
+              ProfileWidget(driver),
+              CustomRatingBarIndicator(rating: 3),
             ],
           ),
         ),

--- a/lib/util/trip/trip_overview.dart
+++ b/lib/util/trip/trip_overview.dart
@@ -15,28 +15,32 @@ class TripOverview extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(trip.start),
-              Text(
-                localeManager.formatTime(trip.startTime),
-                style: DefaultTextStyle.of(context).style.copyWith(fontWeight: FontWeight.w700),
-              )
-            ],
+          child: MergeSemantics(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(trip.start),
+                Text(
+                  localeManager.formatTime(trip.startTime),
+                  style: DefaultTextStyle.of(context).style.copyWith(fontWeight: FontWeight.w700),
+                )
+              ],
+            ),
           ),
         ),
         const Icon(Icons.arrow_forward_rounded),
         Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Text(trip.end),
-              Text(
-                localeManager.formatTime(trip.endTime),
-                style: DefaultTextStyle.of(context).style.copyWith(fontWeight: FontWeight.w700),
-              )
-            ],
+          child: MergeSemantics(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(trip.end),
+                Text(
+                  localeManager.formatTime(trip.endTime),
+                  style: DefaultTextStyle.of(context).style.copyWith(fontWeight: FontWeight.w700),
+                )
+              ],
+            ),
           ),
         ),
       ],
@@ -81,7 +85,10 @@ class TripOverview extends StatelessWidget {
               : Theme.of(context).colorScheme.onSurface.withOpacity(0.3),
         ),
       );
-      text = Text("${maxUsedSeats ?? '?'}/${trip.seats} ${S.of(context).seats}");
+      text = Text(
+        "${maxUsedSeats ?? '?'}/${trip.seats} ${S.of(context).seats}",
+        semanticsLabel: "${maxUsedSeats ?? 'unknown number'} of ${trip.seats} seats",
+      );
     } else {
       seatIcons = List.generate(
         trip.seats,

--- a/lib/util/trip/trip_overview.dart
+++ b/lib/util/trip/trip_overview.dart
@@ -102,11 +102,13 @@ class TripOverview extends StatelessWidget {
       text = Text(S.of(context).seatsCount(trip.seats));
     }
 
-    return Column(
-      children: [
-        Row(children: seatIcons),
-        text,
-      ],
+    return MergeSemantics(
+      child: Column(
+        children: [
+          Row(children: seatIcons),
+          text,
+        ],
+      ),
     );
   }
 }

--- a/lib/util/trip/trip_overview.dart
+++ b/lib/util/trip/trip_overview.dart
@@ -87,7 +87,9 @@ class TripOverview extends StatelessWidget {
       );
       text = Text(
         "${maxUsedSeats ?? '?'}/${trip.seats} ${S.of(context).seats}",
-        semanticsLabel: "${maxUsedSeats ?? 'unknown number'} of ${trip.seats} seats",
+        semanticsLabel: maxUsedSeats != null
+            ? S.of(context).labelXOfYseats(maxUsedSeats, trip.seats)
+            : S.of(context).labelUnknownSeats(trip.seats),
       );
     } else {
       seatIcons = List.generate(

--- a/lib/util/trip/trip_page_builder.dart
+++ b/lib/util/trip/trip_page_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:motis_mitfahr_app/util/trip/trip.dart';
 import 'package:motis_mitfahr_app/util/trip/trip_card.dart';
 import 'package:motis_mitfahr_app/util/trip/trip_stream_builder.dart';
@@ -29,23 +30,26 @@ class TripPageBuilder {
             ],
           ),
         ),
-        body: TabBarView(
-          children: [
-            TripStreamBuilder<T>(
-              stream: trips,
-              emptyMessage: S.of(context).widgetTripBuilderNoUpcoming(name),
-              filterTrips: (trips) => trips.where((trip) => trip.endTime.isAfter(DateTime.now())).toList(),
-              tripCard: tripCard,
-            ),
-            TripStreamBuilder<T>(
-              stream: trips,
-              emptyMessage: S.of(context).widgetTripBuilderNoPast(name),
-              filterTrips: (trips) => trips.reversed.where((trip) => trip.endTime.isBefore(DateTime.now())).toList(),
-              tripCard: tripCard,
-            ),
-          ],
+        body: Semantics(
+          sortKey: const OrdinalSortKey(1),
+          child: TabBarView(
+            children: [
+              TripStreamBuilder<T>(
+                stream: trips,
+                emptyMessage: S.of(context).widgetTripBuilderNoUpcoming(name),
+                filterTrips: (trips) => trips.where((trip) => trip.endTime.isAfter(DateTime.now())).toList(),
+                tripCard: tripCard,
+              ),
+              TripStreamBuilder<T>(
+                stream: trips,
+                emptyMessage: S.of(context).widgetTripBuilderNoPast(name),
+                filterTrips: (trips) => trips.reversed.where((trip) => trip.endTime.isBefore(DateTime.now())).toList(),
+                tripCard: tripCard,
+              ),
+            ],
+          ),
         ),
-        floatingActionButton: floatingActionButton,
+        floatingActionButton: Semantics(sortKey: const OrdinalSortKey(0), child: floatingActionButton),
       ),
     );
   }

--- a/lib/welcome/pages/login_page.dart
+++ b/lib/welcome/pages/login_page.dart
@@ -1,6 +1,7 @@
 import 'dart:core';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:motis_mitfahr_app/util/email_field.dart';
 import 'package:motis_mitfahr_app/util/loading_button.dart';
 import 'package:motis_mitfahr_app/util/password_field.dart';
@@ -77,6 +78,8 @@ class _LoginFormState extends State<LoginForm> {
                 ? S.of(context).pageLoginFailureCredentials
                 : S.of(context).pageLoginFailureEmailNotConfirmed
             : S.of(context).failureSnackBar;
+
+        SemanticsService.announce(text, TextDirection.ltr);
 
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(text),


### PR DESCRIPTION
Finally, accessibility!

There are basically 3 ways to improve the user experience of people with disabilities:
* **Large fonts**,
* **Screen readers**, and
* **Sufficient contrast**.

I tested our app with the largest selectable font in Android and it worked fine. In terms of contrast, I think we are already on the right track, but in the future, I think it will be helpful to include automated tests for meeting accessibility guidelines that are, as far as I know, relatively easy to implement. This and more about accessibility in Flutter you can find here: https://docs.flutter.dev/development/accessibility-and-localization/accessibility.


So, this mostly includes changes about the UX with **Screen Readers**. To test this, as the Android Studio emulator doesn't offer Screen Reader support out of the box and most versions (e.g. the Pixel 6 one) don't include the Play Store, you have to download the Android Accessibility Suite APK ([here](https://apkpure.com/android-accessibility-suite/com.google.android.marvin.talkback/download?from=details), for example) and drag-n-drop it into the emulator window.

tl;dr on Screen Readers: You can swipe left and right to go back and forth between semantic elements, or you can tap once on them. You can douple-tap to activate buttons or text fields.

Mostly these improvements are done with ```Semantics```, which bundles its child as one semantic entity. In the simplest cases, ```MergeSemantics``` is sufficient, which tells Flutter that its child has to be read as one entity so that users don't have to swipe right too often. ```Semantics``` is much more powerful. It can do the same thing if ```excludeSemantics``` is set to true, but it can also tell users if entities are buttons and what they are going to do if clicked (this is standard behavior that should always be implemented! Most Flutter buttons do this automatically, but Inkwells are, in my experience, not treated as buttons by Screen Readers and it would be nice for some buttons that are not self-explanatory to assign a ```tooltip```). You can also change the order in which elements are selected when swiping right, which I used to read the Trip FABs before the list of trips, which could be too long.

Note that you will probably need to test if accessibility works for your features every time.