### PR TITLE
change cancel drive

### DIFF
--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -134,12 +134,7 @@ class Drive extends Trip {
   Future<void> cancel() async {
     cancelled = true;
     await supabaseClient.from('drives').update({'cancelled': true}).eq('id', id);
-    //cancel all pending and approved rides for this drive.
-    await supabaseClient
-        .from('rides')
-        .update({'status': RideStatus.cancelledByDriver.index})
-        .eq('drive_id', id)
-        .or('status.eq.${RideStatus.pending.index},status.eq.${RideStatus.approved.index}');
+    //the rides get updated automatically by a supabase function.
   }
 
   @override


### PR DESCRIPTION
I added a supabase trigger that updates the rides automatically as we cancel the drive. Therefore we don't net the code for that anymore and also the RLS policy that allows drivers to update rides. 
Pleas review the function in Supabase [here](https://app.supabase.com/project/khvzghkhzkjmnbagbzkm/database/functions) and the trigger [here](https://app.supabase.com/project/khvzghkhzkjmnbagbzkm/database/triggers) you can test if it works also via the admin. Just to avoid confusion the new Parameter in the function is the changed row, this parameter is in every trigger available and has to be returned at the end.