### PR TITLE
fix search history fuzzy sort

### DIFF
--- a/lib/util/search/address_suggestion.dart
+++ b/lib/util/search/address_suggestion.dart
@@ -63,8 +63,6 @@ class AddressSuggestion {
   }
 
   static List<AddressSuggestion> deduplicate(List<AddressSuggestion> suggestions) {
-    suggestions.sort((a, b) => a.compareTo(b));
-
     var seen = <AddressSuggestion>{};
     return suggestions.where((suggestion) => seen.add(suggestion)).toList();
   }
@@ -85,11 +83,11 @@ class AddressSuggestion {
       name: json['name'],
       position: Position.fromJson(json['position']),
       type: AddressSuggestionType.values.firstWhere((e) => e.name == json['type']),
-      postalCode: json['postalCode'],
+      postalCode: json['postal_code'],
       city: json['city'],
       country: json['country'],
       fromHistory: fromHistory,
-      lastUsed: json['lastUsed'] != null ? DateTime.parse(json['lastUsed']) : DateTime.now(),
+      lastUsed: json['last_used'] != null ? DateTime.parse(json['last_used']) : DateTime.now(),
     );
   }
 
@@ -98,7 +96,7 @@ class AddressSuggestion {
       'name': name,
       'position': position.toJson(),
       'type': type.name,
-      'postalCode': postalCode,
+      'postal_code': postalCode,
       'city': city,
       'country': country,
       'last_used': lastUsed.toIso8601String(),


### PR DESCRIPTION
co-authored by @fynsta 

Hey y'all! We bring great fixes! Your results from the search history should now be actually correctly ordered, and not, you know, in the exact opposite order.

To do this, we went on a bit of a journey. We wandered through the ever-expanding realms of our app and noticed a bug, idly laying in our way. So we decided to hit it head-on! But then, much to our surprise, he brought his friends, three _other bugs_!

1. We noticed that the compareTo method of the extension wasn't actually called because Dart prioritizes instance methods over extension methods of the same name.
2. The compareTo method returned the exact wrong order.
3. After the compareTo method was called, the deduplicate method sorted the suggestion list again, giving us - you guessed it - the exact wrong order again.
4. Finally, the cases of the JSON that stores the history searches were all messed up! Apparently, the hard decision between snake_case and camelCase led to an unfortunate combination of the two, leading to lastUsed always being null.

So, we decided to put the poor pesky bugs in a basket, presenting them to you proudly. May we be able to roam through the beautiful scenery of functionality again soon!

**WARNING:** You will need to clear your search history so that the JSON files are stored and can be read correctly! 