### PR TITLE
Fix register snackbar

### DIFF
--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -90,7 +90,7 @@ class _RegisterFormState extends State<RegisterForm> {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
             content: Text(S.of(context).pageRegisterSuccess),
-            duration: Duration(seconds: double.infinity.toInt()),
+            duration: const Duration(seconds: 10),
           ));
         }
       }


### PR DESCRIPTION
Just a quick PR to fix the snackbar that is shown on Register. We had just wanted to let it stay there forever, but `double.infinity` cannot be converted to integer. 10 seconds should be enough though.