### PR TITLE
Fix small bug when leaving report unfinished

### DIFF
--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -277,7 +277,7 @@ class _ProfilePageState extends State<ProfilePage> {
                     Navigator.of(context)
                         .push(MaterialPageRoute(builder: (context) => WriteReportPage(_profile!)))
                         .then((reportSent) {
-                      if (reportSent) {
+                      if (reportSent == true) {
                         loadProfile();
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(content: Text(S.of(context).pageProfileButtonMessage)),


### PR DESCRIPTION
I had forgotten that is not typed, its dynamic... so need to check for `true` explicitly.

@Eddie-42 while we're here: I had overflowing text on the report page. Could you maybe fix that as part of this PR?