### PR TITLE
Always specify types

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,5 +12,6 @@ include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     - always_declare_return_types
+    - always_specify_types
     - avoid_dynamic_calls
     - prefer_relative_imports

--- a/lib/account/models/profile.dart
+++ b/lib/account/models/profile.dart
@@ -49,7 +49,8 @@ class Profile extends Model {
 
   bool get isCurrentUser => id == SupabaseManager.getCurrentProfile()?.id;
 
-  List<Feature>? get features => profileFeatures?.map((profileFeature) => profileFeature.feature).toList();
+  List<Feature>? get features =>
+      profileFeatures?.map((ProfileFeature profileFeature) => profileFeature.feature).toList();
 
   @override
   factory Profile.fromJson(Map<String, dynamic> json) {
@@ -77,12 +78,12 @@ class Profile extends Model {
   }
 
   static List<Profile> fromJsonList(List<Map<String, dynamic>> jsonList) {
-    return jsonList.map((json) => Profile.fromJson(json)).toList();
+    return jsonList.map((Map<String, dynamic> json) => Profile.fromJson(json)).toList();
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'username': username,
       'email': email,
       'description': description,
@@ -97,10 +98,14 @@ class Profile extends Model {
   @override
   Map<String, dynamic> toJsonForApi() {
     return super.toJsonForApi()
-      ..addAll({
-        'reviews_received': reviewsReceived?.map((review) => review.toJsonForApi()).toList() ?? [],
-        'profile_features': profileFeatures?.map((profileFeature) => profileFeature.toJsonForApi()).toList() ?? [],
-        'reports_received': reportsReceived?.map((report) => report.toJsonForApi()).toList() ?? [],
+      ..addAll(<String, dynamic>{
+        'reviews_received':
+            reviewsReceived?.map((Review review) => review.toJsonForApi()).toList() ?? <Map<String, dynamic>>[],
+        'profile_features':
+            profileFeatures?.map((ProfileFeature profileFeature) => profileFeature.toJsonForApi()).toList() ??
+                <Map<String, dynamic>>[],
+        'reports_received':
+            reportsReceived?.map((Report report) => report.toJsonForApi()).toList() ?? <Map<String, dynamic>>[],
       });
   }
 

--- a/lib/account/models/profile_feature.dart
+++ b/lib/account/models/profile_feature.dart
@@ -34,14 +34,15 @@ class ProfileFeature extends Model {
   }
 
   static List<ProfileFeature> fromJsonList(List<Map<String, dynamic>> jsonList) {
-    final list = jsonList.map((json) => ProfileFeature.fromJson(json)).toList();
-    list.sort((a, b) => a.rank - b.rank);
+    final List<ProfileFeature> list =
+        jsonList.map((Map<String, dynamic> json) => ProfileFeature.fromJson(json)).toList();
+    list.sort((ProfileFeature a, ProfileFeature b) => a.rank - b.rank);
     return list;
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'profile_id': profileId,
       'feature': feature.index,
       'rank': rank,
@@ -51,7 +52,7 @@ class ProfileFeature extends Model {
   @override
   Map<String, dynamic> toJsonForApi() {
     return super.toJsonForApi()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'profile': profile?.toJsonForApi(),
       });
   }

--- a/lib/account/models/report.dart
+++ b/lib/account/models/report.dart
@@ -42,12 +42,12 @@ class Report extends Model {
   }
 
   static List<Report> fromJsonList(List<Map<String, dynamic>> jsonList) {
-    return jsonList.map((json) => Report.fromJson(json)).toList();
+    return jsonList.map((Map<String, dynamic> json) => Report.fromJson(json)).toList();
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'offender_id': offenderId,
       'reporter_id': reporterId,
       'category': category.index,
@@ -58,7 +58,7 @@ class Report extends Model {
   @override
   Map<String, dynamic> toJsonForApi() {
     return super.toJsonForApi()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'offender': offender?.toJsonForApi(),
         'reporter': reporter?.toJsonForApi(),
       });

--- a/lib/account/models/review.dart
+++ b/lib/account/models/review.dart
@@ -1,5 +1,4 @@
 import '../../util/model.dart';
-import '../../util/profiles/reviews/aggregate_review_widget.dart';
 import 'profile.dart';
 
 class Review extends Model implements Comparable<Review> {
@@ -52,12 +51,12 @@ class Review extends Model implements Comparable<Review> {
   }
 
   static List<Review> fromJsonList(List<Map<String, dynamic>> jsonList) {
-    return jsonList.map((json) => Review.fromJson(json)).toList();
+    return jsonList.map((Map<String, dynamic> json) => Review.fromJson(json)).toList();
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'rating': rating,
       'comfort_rating': comfortRating,
       'safety_rating': safetyRating,
@@ -72,7 +71,7 @@ class Review extends Model implements Comparable<Review> {
   @override
   Map<String, dynamic> toJsonForApi() {
     return super.toJsonForApi()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'writer': writer?.toJsonForApi(),
         'receiver': receiver?.toJsonForApi(),
       });
@@ -121,34 +120,33 @@ class AggregateReview {
   bool get isReliabilitySet => reliabilityRating != 0;
   bool get isHospitalitySet => hospitalityRating != 0;
 
-  AggregateReviewWidget widget() {
-    return AggregateReviewWidget(this);
-  }
-
   factory AggregateReview.fromReviews(List<Review> reviews) {
-    double rating =
-        reviews.isEmpty ? 0 : reviews.map((review) => review.rating).reduce((a, b) => a + b) / reviews.length;
+    double rating = reviews.isEmpty
+        ? 0
+        : reviews.map((Review review) => review.rating).reduce((int a, int b) => a + b) / reviews.length;
 
-    List<Review> comfortReviews = reviews.where((review) => review.comfortRating != null).toList();
+    List<Review> comfortReviews = reviews.where((Review review) => review.comfortRating != null).toList();
     double comfortRating = comfortReviews.isEmpty
         ? 0
-        : comfortReviews.map((review) => review.comfortRating!).reduce((a, b) => a + b) / comfortReviews.length;
+        : comfortReviews.map((Review review) => review.comfortRating!).reduce((int a, int b) => a + b) /
+            comfortReviews.length;
 
-    List<Review> safetyReviews = reviews.where((review) => review.safetyRating != null).toList();
+    List<Review> safetyReviews = reviews.where((Review review) => review.safetyRating != null).toList();
     double safetyRating = safetyReviews.isEmpty
         ? 0
-        : safetyReviews.map((review) => review.safetyRating!).reduce((a, b) => a + b) / safetyReviews.length;
+        : safetyReviews.map((Review review) => review.safetyRating!).reduce((int a, int b) => a + b) /
+            safetyReviews.length;
 
-    List<Review> reliabilityReviews = reviews.where((review) => review.reliabilityRating != null).toList();
+    List<Review> reliabilityReviews = reviews.where((Review review) => review.reliabilityRating != null).toList();
     double reliabilityRating = reliabilityReviews.isEmpty
         ? 0
-        : reliabilityReviews.map((review) => review.reliabilityRating!).reduce((a, b) => a + b) /
+        : reliabilityReviews.map((Review review) => review.reliabilityRating!).reduce((int a, int b) => a + b) /
             reliabilityReviews.length;
 
-    List<Review> hospitalityReviews = reviews.where((review) => review.hospitalityRating != null).toList();
+    List<Review> hospitalityReviews = reviews.where((Review review) => review.hospitalityRating != null).toList();
     double averageRating = hospitalityReviews.isEmpty
         ? 0
-        : hospitalityReviews.map((review) => review.hospitalityRating!).reduce((a, b) => a + b) /
+        : hospitalityReviews.map((Review review) => review.hospitalityRating!).reduce((int a, int b) => a + b) /
             hospitalityReviews.length;
 
     return AggregateReview(

--- a/lib/account/pages/about_page.dart
+++ b/lib/account/pages/about_page.dart
@@ -23,7 +23,7 @@ class _AboutPageState extends State<AboutPage> {
   void initState() {
     super.initState();
     PackageInfo.fromPlatform().then(
-      (value) => setState(
+      (PackageInfo value) => setState(
         () => _packageInfo = value,
       ),
     );
@@ -42,19 +42,19 @@ class _AboutPageState extends State<AboutPage> {
       body: Center(
         child: CustomScrollView(
           physics: const ClampingScrollPhysics(),
-          slivers: [
+          slivers: <Widget>[
             SliverFillRemaining(
               hasScrollBody: false,
               child: Padding(
                 padding: const EdgeInsets.all(10),
-                child: Column(children: [
+                child: Column(children: <Widget>[
                   Expanded(child: Container()),
                   Text(
                     S.of(context).appName,
                     style: Theme.of(context).textTheme.headlineMedium,
                     textAlign: TextAlign.center,
                   ),
-                  if (_packageInfo != null) ...[
+                  if (_packageInfo != null) ...<Widget>[
                     Text(
                       S.of(context).pageAboutVersion(_packageInfo!.version),
                       style: packageInfoStyle,
@@ -84,7 +84,7 @@ class _AboutPageState extends State<AboutPage> {
                   Expanded(
                     child: Align(
                       alignment: Alignment.bottomCenter,
-                      child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                      child: Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
                         TextButton(
                           onPressed: () async => await launchUrlString(
                             githubLink,

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -20,12 +20,12 @@ class _AccountPageState extends State<AccountPage> {
     showDialog(
       context: context,
       builder: (BuildContext context) => StatefulBuilder(
-        builder: (context, innerSetState) => AlertDialog(
+        builder: (BuildContext context, Function(VoidCallback) innerSetState) => AlertDialog(
           content: Column(
             mainAxisSize: MainAxisSize.min,
-            children: List.generate(
+            children: List<RadioListTile<ThemeMode>>.generate(
               ThemeMode.values.length,
-              (index) => RadioListTile(
+              (int index) => RadioListTile<ThemeMode>(
                   title: Text(
                     ThemeMode.values[index].getName(context),
                   ),
@@ -53,13 +53,13 @@ class _AccountPageState extends State<AccountPage> {
     showDialog(
       context: context,
       builder: (BuildContext context) => StatefulBuilder(
-        builder: (context, innerSetState) => AlertDialog(
+        builder: (BuildContext context, Function(VoidCallback) innerSetState) => AlertDialog(
           content: Column(
             mainAxisSize: MainAxisSize.min,
-            children: List.generate(
+            children: List<RadioListTile<Locale>>.generate(
               localeManager.supportedLocales.length,
-              (index) => RadioListTile(
-                title: Text(localeManager.supportedLocales.map((e) => e.languageName).toList()[index]),
+              (int index) => RadioListTile<Locale>(
+                title: Text(localeManager.supportedLocales.map((Locale e) => e.languageName).toList()[index]),
                 value: localeManager.supportedLocales[index],
                 groupValue: localeManager.currentLocale,
                 onChanged: (Locale? value) {
@@ -101,7 +101,7 @@ class _AccountPageState extends State<AccountPage> {
         title: Text(S.of(context).pageAccountTitle),
       ),
       body: ListView(
-        children: [
+        children: <Widget>[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 5),
             child: ProfileWidget(
@@ -127,8 +127,8 @@ class _AccountPageState extends State<AccountPage> {
             leading: const Icon(Icons.help),
             title: Text(S.of(context).pageAccountHelp),
             onTap: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const HelpPage(),
+              MaterialPageRoute<void>(
+                builder: (BuildContext context) => const HelpPage(),
               ),
             ),
           ),
@@ -136,8 +136,8 @@ class _AccountPageState extends State<AccountPage> {
             leading: const Icon(Icons.info),
             title: Text(S.of(context).pageAccountAbout),
             onTap: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const AboutPage(),
+              MaterialPageRoute<void>(
+                builder: (BuildContext context) => const AboutPage(),
               ),
             ),
           ),

--- a/lib/account/pages/edit_account/edit_birth_date_page.dart
+++ b/lib/account/pages/edit_account/edit_birth_date_page.dart
@@ -35,7 +35,7 @@ class _EditBirthDatePageState extends State<EditBirthDatePage> {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: Column(
-            children: [
+            children: <Widget>[
               TextField(
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),
@@ -46,9 +46,7 @@ class _EditBirthDatePageState extends State<EditBirthDatePage> {
                 onTap: _showDatePicker,
                 controller: _controller,
               ),
-              const SizedBox(
-                height: 10,
-              ),
+              const SizedBox(height: 10),
               Button(
                 S.of(context).save,
                 onPressed: onPressed,
@@ -75,7 +73,7 @@ class _EditBirthDatePageState extends State<EditBirthDatePage> {
   }
 
   void _showDatePicker() async {
-    final twelveYearsAgo = DateTime.now().subtract(const Duration(days: 365 * 12));
+    final DateTime twelveYearsAgo = DateTime.now().subtract(const Duration(days: 365 * 12));
     DateTime? date = await showDatePicker(
       context: context,
       initialDate: twelveYearsAgo,
@@ -89,8 +87,8 @@ class _EditBirthDatePageState extends State<EditBirthDatePage> {
   }
 
   void onPressed() async {
-    final date = _date == null ? null : _date!.toString();
-    await SupabaseManager.supabaseClient.from('profiles').update({
+    final String? date = _date == null ? null : _date!.toString();
+    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'birth_date': date,
     }).eq('id', widget.profile.id);
     SupabaseManager.reloadCurrentProfile();

--- a/lib/account/pages/edit_account/edit_description_page.dart
+++ b/lib/account/pages/edit_account/edit_description_page.dart
@@ -5,12 +5,22 @@ import '../../../util/buttons/button.dart';
 import '../../../util/supabase.dart';
 import '../../models/profile.dart';
 
-class EditDescriptionPage extends StatelessWidget {
+class EditDescriptionPage extends StatefulWidget {
   final Profile profile;
+
+  const EditDescriptionPage(this.profile, {super.key});
+
+  @override
+  State<EditDescriptionPage> createState() => _EditDescriptionPageState();
+}
+
+class _EditDescriptionPageState extends State<EditDescriptionPage> {
   final TextEditingController _controller = TextEditingController();
 
-  EditDescriptionPage(this.profile, {super.key}) {
-    _controller.text = profile.description ?? '';
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.profile.description ?? '';
   }
 
   @override
@@ -23,22 +33,20 @@ class EditDescriptionPage extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: Column(
-            children: [
+            children: <Widget>[
               TextField(
                 maxLines: 10,
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),
                   hintText: S.of(context).pageProfileEditDescriptionHint,
-                  suffixIcon: _getClearButton(context),
+                  suffixIcon: _getClearButton(),
                 ),
                 controller: _controller,
               ),
-              const SizedBox(
-                height: 10,
-              ),
+              const SizedBox(height: 10),
               Button(
                 S.of(context).save,
-                onPressed: () => onPressed(context),
+                onPressed: onPressed,
               ),
             ],
           ),
@@ -47,7 +55,7 @@ class EditDescriptionPage extends StatelessWidget {
     );
   }
 
-  Widget? _getClearButton(BuildContext context) {
+  Widget? _getClearButton() {
     if (_controller.text == '') {
       return null;
     }
@@ -58,13 +66,13 @@ class EditDescriptionPage extends StatelessWidget {
     );
   }
 
-  void onPressed(context) async {
+  void onPressed() async {
     String? text = _controller.text == '' ? null : _controller.text;
-    await SupabaseManager.supabaseClient.from('profiles').update({
+    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'description': text,
-    }).eq('id', profile.id);
+    }).eq('id', widget.profile.id);
     SupabaseManager.reloadCurrentProfile();
 
-    Navigator.of(context).pop();
+    if (mounted) Navigator.of(context).pop();
   }
 }

--- a/lib/account/pages/edit_account/edit_full_name_page.dart
+++ b/lib/account/pages/edit_account/edit_full_name_page.dart
@@ -5,14 +5,24 @@ import '../../../util/buttons/button.dart';
 import '../../../util/supabase.dart';
 import '../../models/profile.dart';
 
-class EditFullNamePage extends StatelessWidget {
+class EditFullNamePage extends StatefulWidget {
   final Profile profile;
+
+  const EditFullNamePage(this.profile, {super.key});
+
+  @override
+  State<EditFullNamePage> createState() => _EditFullNamePageState();
+}
+
+class _EditFullNamePageState extends State<EditFullNamePage> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _surnameController = TextEditingController();
 
-  EditFullNamePage(this.profile, {super.key}) {
-    _nameController.text = profile.name ?? '';
-    _surnameController.text = profile.surname ?? '';
+  @override
+  void initState() {
+    super.initState();
+    _nameController.text = widget.profile.name ?? '';
+    _surnameController.text = widget.profile.surname ?? '';
   }
 
   @override
@@ -25,32 +35,28 @@ class EditFullNamePage extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: Column(
-            children: [
+            children: <Widget>[
               TextField(
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),
                   hintText: S.of(context).pageProfileEditSurnameHint,
-                  suffixIcon: _getClearButton(context, _surnameController),
+                  suffixIcon: _getClearButton(_surnameController),
                 ),
                 controller: _surnameController,
               ),
-              const SizedBox(
-                height: 10,
-              ),
+              const SizedBox(height: 10),
               TextField(
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),
                   hintText: S.of(context).pageProfileEditNameHint,
-                  suffixIcon: _getClearButton(context, _nameController),
+                  suffixIcon: _getClearButton(_nameController),
                 ),
                 controller: _nameController,
               ),
-              const SizedBox(
-                height: 10,
-              ),
+              const SizedBox(height: 10),
               Button(
                 S.of(context).save,
-                onPressed: () => onPressed(context),
+                onPressed: onPressed,
               ),
             ],
           ),
@@ -59,7 +65,7 @@ class EditFullNamePage extends StatelessWidget {
     );
   }
 
-  Widget? _getClearButton(BuildContext context, TextEditingController controller) {
+  Widget? _getClearButton(TextEditingController controller) {
     if (controller.text == '') {
       return null;
     }
@@ -70,15 +76,15 @@ class EditFullNamePage extends StatelessWidget {
     );
   }
 
-  void onPressed(context) async {
+  void onPressed() async {
     String? surname = _surnameController.text == '' ? null : _surnameController.text;
     String? name = _nameController.text == '' ? null : _nameController.text;
-    await SupabaseManager.supabaseClient.from('profiles').update({
+    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'surname': surname,
       'name': name,
-    }).eq('id', profile.id);
+    }).eq('id', widget.profile.id);
     SupabaseManager.reloadCurrentProfile();
 
-    Navigator.of(context).pop();
+    if (mounted) Navigator.of(context).pop();
   }
 }

--- a/lib/account/pages/edit_account/edit_gender_page.dart
+++ b/lib/account/pages/edit_account/edit_gender_page.dart
@@ -33,13 +33,13 @@ class _EditGenderPageState extends State<EditGenderPage> {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: Column(
-            children: [
-              ...List.generate(
+            children: <Widget>[
+              ...List<RadioListTile<Gender?>>.generate(
                 Gender.values.length + 1,
-                (index) {
+                (int index) {
                   if (index < Gender.values.length) {
-                    final gender = Gender.values[index];
-                    return RadioListTile(
+                    final Gender gender = Gender.values[index];
+                    return RadioListTile<Gender>(
                       title: Text(gender.getName(context)),
                       value: gender,
                       groupValue: _gender,
@@ -62,12 +62,10 @@ class _EditGenderPageState extends State<EditGenderPage> {
                   );
                 },
               ),
-              const SizedBox(
-                height: 10,
-              ),
+              const SizedBox(height: 10),
               Button(
                 S.of(context).save,
-                onPressed: () => onPressed(context),
+                onPressed: onPressed,
               ),
             ],
           ),
@@ -76,12 +74,12 @@ class _EditGenderPageState extends State<EditGenderPage> {
     );
   }
 
-  void onPressed(context) async {
-    await SupabaseManager.supabaseClient.from('profiles').update({
+  void onPressed() async {
+    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'gender': _gender?.index,
     }).eq('id', widget.profile.id);
     SupabaseManager.reloadCurrentProfile();
 
-    Navigator.of(context).pop();
+    if (mounted) Navigator.of(context).pop();
   }
 }

--- a/lib/account/pages/edit_account/edit_username_page.dart
+++ b/lib/account/pages/edit_account/edit_username_page.dart
@@ -5,13 +5,23 @@ import '../../../util/buttons/button.dart';
 import '../../../util/supabase.dart';
 import '../../models/profile.dart';
 
-class EditUsernamePage extends StatelessWidget {
+class EditUsernamePage extends StatefulWidget {
   final Profile profile;
-  final _formKey = GlobalKey<FormState>();
+
+  const EditUsernamePage(this.profile, {super.key});
+
+  @override
+  State<EditUsernamePage> createState() => _EditUsernamePageState();
+}
+
+class _EditUsernamePageState extends State<EditUsernamePage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _controller = TextEditingController();
 
-  EditUsernamePage(this.profile, {super.key}) {
-    _controller.text = profile.username;
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.profile.username;
   }
 
   @override
@@ -26,28 +36,26 @@ class EditUsernamePage extends StatelessWidget {
           child: Form(
             key: _formKey,
             child: Column(
-              children: [
+              children: <Widget>[
                 TextFormField(
                   maxLength: 15,
                   decoration: InputDecoration(
                     border: const OutlineInputBorder(),
                     hintText: S.of(context).pageProfileEditUsernameHint,
-                    suffixIcon: _getClearButton(context),
+                    suffixIcon: _getClearButton(),
                   ),
                   controller: _controller,
-                  validator: (value) {
+                  validator: (String? value) {
                     if (value == null || value.isEmpty) {
                       return S.of(context).pageProfileEditUsernameValidateEmpty;
                     }
                     return null;
                   },
                 ),
-                const SizedBox(
-                  height: 10,
-                ),
+                const SizedBox(height: 10),
                 Button(
                   S.of(context).save,
-                  onPressed: () => onPressed(context),
+                  onPressed: onPressed,
                 ),
               ],
             ),
@@ -57,7 +65,7 @@ class EditUsernamePage extends StatelessWidget {
     );
   }
 
-  Widget? _getClearButton(BuildContext context) {
+  Widget? _getClearButton() {
     if (_controller.text == '') {
       return null;
     }
@@ -68,15 +76,15 @@ class EditUsernamePage extends StatelessWidget {
     );
   }
 
-  void onPressed(context) async {
+  void onPressed() async {
     if (!_formKey.currentState!.validate()) {
       return;
     }
-    await SupabaseManager.supabaseClient.from('profiles').update({
+    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'username': _controller.text,
-    }).eq('id', profile.id);
+    }).eq('id', widget.profile.id);
     SupabaseManager.reloadCurrentProfile();
 
-    Navigator.of(context).pop();
+    if (mounted) Navigator.of(context).pop();
   }
 }

--- a/lib/account/pages/help_page.dart
+++ b/lib/account/pages/help_page.dart
@@ -14,7 +14,7 @@ class HelpPage extends StatefulWidget {
 }
 
 class _HelpPageState extends State<HelpPage> {
-  List<Widget> getFaqCards() => [
+  List<Widget> getFaqCards() => <Widget>[
         FAQCard(
           question: S.of(context).pageHelpQuestion1,
           answer: S.of(context).pageHelpAnswer1,
@@ -90,7 +90,7 @@ class _HelpPageState extends State<HelpPage> {
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
         child: ListView(
           children: getFaqCards() +
-              [
+              <Widget>[
                 const Divider(
                   thickness: 1,
                 ),
@@ -130,7 +130,7 @@ class _FAQCardState extends State<FAQCard> {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       child: ExpansionTile(
         title: question,
-        children: [
+        children: <Widget>[
           Semantics(
             liveRegion: true,
             child: Padding(

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:image_picker/image_picker.dart';
@@ -7,6 +9,7 @@ import '../../util/buttons/button.dart';
 import '../../util/locale_manager.dart';
 import '../../util/supabase.dart';
 import '../models/profile.dart';
+import '../models/report.dart';
 import '../widgets/avatar.dart';
 import '../widgets/editable_row.dart';
 import '../widgets/features_column.dart';
@@ -75,7 +78,7 @@ class _ProfilePageState extends State<ProfilePage> {
     if (_profile!.isCurrentUser) {
       return Row(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: [
+        children: <Widget>[
           Expanded(child: Container()),
           username,
           Expanded(
@@ -86,8 +89,8 @@ class _ProfilePageState extends State<ProfilePage> {
                 icon: const Icon(Icons.edit),
                 onPressed: () {
                   Navigator.of(context)
-                      .push(MaterialPageRoute(builder: (context) => EditUsernamePage(_profile!)))
-                      .then((value) => loadProfile());
+                      .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditUsernamePage(_profile!)))
+                      .then((_) => loadProfile());
                 },
               ),
             ),
@@ -119,8 +122,8 @@ class _ProfilePageState extends State<ProfilePage> {
       isEditable: _profile!.isCurrentUser,
       onPressed: () {
         Navigator.of(context)
-            .push(MaterialPageRoute(builder: (context) => EditDescriptionPage(_profile!)))
-            .then((value) => loadProfile());
+            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditDescriptionPage(_profile!)))
+            .then((_) => loadProfile());
       },
     );
   }
@@ -138,8 +141,8 @@ class _ProfilePageState extends State<ProfilePage> {
       isEditable: _profile!.isCurrentUser,
       onPressed: () {
         Navigator.of(context)
-            .push(MaterialPageRoute(builder: (context) => EditFullNamePage(_profile!)))
-            .then((value) => loadProfile());
+            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditFullNamePage(_profile!)))
+            .then((_) => loadProfile());
       },
     );
   }
@@ -157,8 +160,8 @@ class _ProfilePageState extends State<ProfilePage> {
       isEditable: _profile!.isCurrentUser,
       onPressed: () {
         Navigator.of(context)
-            .push(MaterialPageRoute(builder: (context) => EditBirthDatePage(_profile!)))
-            .then((value) => loadProfile());
+            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditBirthDatePage(_profile!)))
+            .then((_) => loadProfile());
       },
     );
   }
@@ -177,8 +180,8 @@ class _ProfilePageState extends State<ProfilePage> {
       isEditable: _profile!.isCurrentUser,
       onPressed: () {
         Navigator.of(context)
-            .push(MaterialPageRoute(builder: (context) => EditGenderPage(_profile!)))
-            .then((value) => loadProfile());
+            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditGenderPage(_profile!)))
+            .then((_) => loadProfile());
       },
     );
   }
@@ -193,14 +196,14 @@ class _ProfilePageState extends State<ProfilePage> {
       isEditable: _profile!.isCurrentUser,
       onPressed: () {
         Navigator.of(context)
-            .push(MaterialPageRoute(builder: (context) => EditProfileFeaturesPage(_profile!)))
-            .then((value) => loadProfile());
+            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditProfileFeaturesPage(_profile!)))
+            .then((_) => loadProfile());
       },
     );
   }
 
   Widget buildReviews() {
-    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
       Text(
         S.of(context).pageProfileReviewsTitle,
         style: Theme.of(context).textTheme.headline6,
@@ -221,11 +224,11 @@ class _ProfilePageState extends State<ProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> widgets = [
+    List<Widget> widgets = <Widget>[
       buildAvatar(),
       const SizedBox(height: 8),
       buildUsername(),
-      if (_profile!.isCurrentUser) ...[
+      if (_profile!.isCurrentUser) ...<Widget>[
         buildEmail(),
       ],
       const SizedBox(height: 8),
@@ -233,39 +236,39 @@ class _ProfilePageState extends State<ProfilePage> {
       const SizedBox(height: 8),
     ];
     if (_profile!.isCurrentUser || _profile!.fullName.isNotEmpty) {
-      widgets.addAll([
+      widgets.addAll(<Widget>[
         buildFullName(),
         const SizedBox(height: 16),
       ]);
     }
     if (_profile!.isCurrentUser || (_profile!.description?.isNotEmpty ?? false)) {
-      widgets.addAll([
+      widgets.addAll(<Widget>[
         buildDescription(),
         const SizedBox(height: 16),
       ]);
     }
     if (_profile!.isCurrentUser || _profile!.birthDate != null) {
-      widgets.addAll([
+      widgets.addAll(<Widget>[
         buildBirthDate(),
         const SizedBox(height: 16),
       ]);
     }
     if (_profile!.isCurrentUser || _profile!.gender != null) {
-      widgets.addAll([
+      widgets.addAll(<Widget>[
         buildGender(),
         const SizedBox(height: 16),
       ]);
     }
     if (_fullyLoaded) {
       if (_profile!.isCurrentUser || _profile!.profileFeatures!.isNotEmpty) {
-        widgets.addAll([buildFeatures(), const SizedBox(height: 16)]);
+        widgets.addAll(<Widget>[buildFeatures(), const SizedBox(height: 16)]);
       }
       widgets.add(buildReviews());
       if (!_profile!.isCurrentUser) {
         bool hasRecentReport = _profile!.reportsReceived!
-            .any((report) => report.isRecent && report.reporterId == SupabaseManager.getCurrentProfile()!.id);
+            .any((Report report) => report.isRecent && report.reporterId == SupabaseManager.getCurrentProfile()!.id);
 
-        widgets.addAll([
+        widgets.addAll(<Widget>[
           const SizedBox(height: 32),
           hasRecentReport
               ? Button.disabled(
@@ -275,8 +278,8 @@ class _ProfilePageState extends State<ProfilePage> {
                   S.of(context).pageProfileButtonReport,
                   onPressed: () {
                     Navigator.of(context)
-                        .push(MaterialPageRoute(builder: (context) => WriteReportPage(_profile!)))
-                        .then((reportSent) {
+                        .push(MaterialPageRoute<bool?>(builder: (BuildContext context) => WriteReportPage(_profile!)))
+                        .then((bool? reportSent) {
                       if (reportSent == true) {
                         loadProfile();
                         ScaffoldMessenger.of(context).showSnackBar(
@@ -292,14 +295,14 @@ class _ProfilePageState extends State<ProfilePage> {
       widgets.add(const Center(child: CircularProgressIndicator()));
     }
 
-    final content = Column(
+    final Column content = Column(
       children: widgets,
     );
     return Scaffold(
       appBar: AppBar(
         title: Text(_profile?.username ?? ''),
         actions: _profile != null && _profile!.isCurrentUser
-            ? [
+            ? <Widget>[
                 TextButton.icon(
                   onPressed: signOut,
                   icon: const Icon(Icons.logout),
@@ -361,8 +364,8 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> _uploadProfilePicture() async {
-    final picker = ImagePicker();
-    final imageFile = await picker.pickImage(
+    final ImagePicker picker = ImagePicker();
+    final XFile? imageFile = await picker.pickImage(
       source: ImageSource.gallery,
       maxWidth: 300,
       maxHeight: 300,
@@ -372,9 +375,9 @@ class _ProfilePageState extends State<ProfilePage> {
     }
 
     try {
-      final bytes = await imageFile.readAsBytes();
-      final fileExt = imageFile.path.split('.').last;
-      final fileName = '${DateTime.now().toIso8601String()}.$fileExt';
+      final Uint8List bytes = await imageFile.readAsBytes();
+      final String fileExt = imageFile.path.split('.').last;
+      final String fileName = '${DateTime.now().toIso8601String()}.$fileExt';
 
       await SupabaseManager.supabaseClient.storage.from('avatars').uploadBinary(
             fileName,
@@ -382,13 +385,13 @@ class _ProfilePageState extends State<ProfilePage> {
             fileOptions: FileOptions(contentType: imageFile.mimeType),
           );
 
-      final imageUrlResponse = await SupabaseManager.supabaseClient.storage
+      final String imageUrlResponse = await SupabaseManager.supabaseClient.storage
           .from('avatars')
           .createSignedUrl(fileName, 60 * 60 * 24 * 365 * 10);
 
       await SupabaseManager.supabaseClient
           .from('profiles')
-          .update({"avatar_url": imageUrlResponse}).eq('id', _profile!.id);
+          .update(<String, dynamic>{"avatar_url": imageUrlResponse}).eq('id', _profile!.id);
 
       SupabaseManager.reloadCurrentProfile();
       loadProfile();
@@ -402,7 +405,9 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> _deleteProfilePicture() async {
-    await SupabaseManager.supabaseClient.from('profiles').update({"avatar_url": null}).eq('id', _profile!.id);
+    await SupabaseManager.supabaseClient
+        .from('profiles')
+        .update(<String, dynamic>{"avatar_url": null}).eq('id', _profile!.id);
 
     SupabaseManager.reloadCurrentProfile();
     loadProfile();

--- a/lib/account/pages/reviews_page.dart
+++ b/lib/account/pages/reviews_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../rides/models/ride.dart';
 import '../../util/buttons/button.dart';
+import '../../util/parse_helper.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/reviews/aggregate_review_widget.dart';
 import '../../util/supabase.dart';
@@ -47,10 +48,12 @@ class _ReviewsPageState extends State<ReviewsPage> {
         *,
         writer: writer_id(*)
       )''').eq('id', _profileId).single();
-    List<Map<String, dynamic>> commonRidesData = await SupabaseManager.supabaseClient.from('rides').select('''
+    List<Map<String, dynamic>> commonRidesData = parseHelper.parseListOfMaps(
+      await SupabaseManager.supabaseClient.from('rides').select('''
           *,
           drive: drives!inner(*)
-        ''').eq('rider_id', SupabaseManager.getCurrentProfile()!.id).eq('drive.driver_id', _profileId);
+        ''').eq('rider_id', SupabaseManager.getCurrentProfile()!.id).eq('drive.driver_id', _profileId),
+    );
 
     setState(() {
       _profile = Profile.fromJson(profileData);

--- a/lib/account/pages/write_report_page.dart
+++ b/lib/account/pages/write_report_page.dart
@@ -49,15 +49,15 @@ class _WriteReportPageState extends State<WriteReportPage> {
             child: Form(
               key: _formKey,
               child: Column(
-                children: [
+                children: <Widget>[
                   Column(
-                    children: List.generate(
+                    children: List<RadioListTile<ReportCategory>>.generate(
                       ReportCategory.values.length,
-                      (index) {
-                        final category = ReportCategory.values[index];
-                        return RadioListTile(
+                      (int index) {
+                        final ReportCategory category = ReportCategory.values[index];
+                        return RadioListTile<ReportCategory>(
                           visualDensity: VisualDensity.compact,
-                          title: Row(children: [
+                          title: Row(children: <Widget>[
                             category.getIcon(context),
                             const SizedBox(width: 15),
                             Expanded(child: Text(category.getDescription(context))),
@@ -84,7 +84,7 @@ class _WriteReportPageState extends State<WriteReportPage> {
                     ),
                     textAlignVertical: TextAlignVertical.top,
                     maxLines: 5,
-                    validator: (value) {
+                    validator: (String? value) {
                       if ((value == null || value.isEmpty) && _category == ReportCategory.other) {
                         return S.of(context).pageWriteReportFieldValidateEmpty;
                       }
@@ -114,7 +114,7 @@ class _WriteReportPageState extends State<WriteReportPage> {
       _state = ButtonState.loading;
     });
 
-    final report = Report(
+    final Report report = Report(
       offenderId: widget.profile.id!,
       reporterId: SupabaseManager.getCurrentProfile()!.id!,
       category: _category!,

--- a/lib/account/pages/write_review_page.dart
+++ b/lib/account/pages/write_review_page.dart
@@ -69,7 +69,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
             ? const CircularProgressIndicator()
             : SingleChildScrollView(
                 child: Column(
-                  children: [
+                  children: <Widget>[
                     CustomRatingBar(
                       size: CustomRatingBarSize.huge,
                       rating: _review!.rating,
@@ -109,7 +109,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
     return SizedBox(
       width: double.infinity,
       child: Column(
-        children: [
+        children: <Widget>[
           _buildCategoryReviewRow(
             S.of(context).reviewCategoryComfort,
             _review!.comfortRating,
@@ -138,7 +138,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
   Widget _buildCategoryReviewRow(String category, int? rating, Function(double) onRatingUpdate) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
-      children: [
+      children: <Widget>[
         Flexible(child: SizedBox(width: 100, child: Text(category))),
         const SizedBox(width: 10),
         CustomRatingBar(size: CustomRatingBarSize.large, rating: rating, onRatingUpdate: onRatingUpdate),
@@ -192,7 +192,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
         content: Text(S.of(context).pageWriteReviewRatingRequired),
         duration: duration,
       ));
-      await Future.delayed(duration);
+      await Future<void>.delayed(duration);
       setState(() {
         _state = ButtonState.idle;
       });

--- a/lib/account/widgets/avatar.dart
+++ b/lib/account/widgets/avatar.dart
@@ -28,7 +28,7 @@ class AvatarState extends State<Avatar> {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      children: [
+      children: <Widget>[
         Hero(
           tag: "Avatar-${widget.profile.id}",
           child: CircleAvatar(
@@ -53,9 +53,7 @@ class AvatarState extends State<Avatar> {
                 child: InkWell(
                   borderRadius: BorderRadius.circular(widget.size ?? 20),
                   onTap: () => Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => AvatarPicturePage(widget.profile),
-                    ),
+                    MaterialPageRoute<void>(builder: (BuildContext context) => AvatarPicturePage(widget.profile)),
                   ),
                 ),
               ),

--- a/lib/account/widgets/editable_row.dart
+++ b/lib/account/widgets/editable_row.dart
@@ -19,9 +19,9 @@ class EditableRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
+      children: <Widget>[
         Row(
-          children: [
+          children: <Widget>[
             Text(
               title,
               style: Theme.of(context).textTheme.headline6,

--- a/lib/account/widgets/features_column.dart
+++ b/lib/account/widgets/features_column.dart
@@ -10,7 +10,7 @@ class FeaturesColumn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
-      itemBuilder: ((context, index) {
+      itemBuilder: ((BuildContext context, int index) {
         Feature feature = features[index].feature;
         return ListTile(
           leading: feature.getIcon(context),

--- a/lib/account/widgets/review_detail.dart
+++ b/lib/account/widgets/review_detail.dart
@@ -13,7 +13,7 @@ class ReviewDetail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget header = Row(
-      children: [
+      children: <Widget>[
         ProfileChip(review.writer!),
         Text(
           localeManager.formatDate(review.createdAt!),
@@ -35,9 +35,9 @@ class ReviewDetail extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(5),
         child: Column(
-          children: [
+          children: <Widget>[
             header,
-            if (review.text?.isNotEmpty ?? false) ...[
+            if (review.text?.isNotEmpty ?? false) ...<Widget>[
               const SizedBox(
                 height: 5,
               ),

--- a/lib/account/widgets/reviews_preview.dart
+++ b/lib/account/widgets/reviews_preview.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import '../../util/profiles/reviews/aggregate_review_widget.dart';
 import '../models/profile.dart';
 import '../models/review.dart';
 import '../pages/reviews_page.dart';
@@ -15,7 +16,7 @@ class ReviewsPreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<Review> reviews = profile.reviewsReceived!..sort((a, b) => a.compareTo(b));
+    List<Review> reviews = profile.reviewsReceived!..sort((Review a, Review b) => a.compareTo(b));
     AggregateReview aggregateReview = AggregateReview.fromReviews(reviews);
 
     return Semantics(
@@ -23,22 +24,20 @@ class ReviewsPreview extends StatelessWidget {
       button: true,
       tooltip: S.of(context).reviewsPreviewShowReviews,
       child: Stack(
-        children: [
+        children: <Widget>[
           Column(
-            children: [
-              aggregateReview.widget(),
+            children: <Widget>[
+              AggregateReviewWidget(aggregateReview),
               if (reviews.isNotEmpty)
                 ExcludeSemantics(
                   child: Column(
-                    children: [
-                      const SizedBox(
-                        height: 10,
-                      ),
+                    children: <Widget>[
+                      const SizedBox(height: 10),
                       ShaderMask(
-                        shaderCallback: (rect) => const LinearGradient(
+                        shaderCallback: (Rect rect) => const LinearGradient(
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,
-                          colors: [Colors.black, Colors.transparent],
+                          colors: <Color>[Colors.black, Colors.transparent],
                         ).createShader(Rect.fromLTRB(0, 0, rect.width, rect.height)),
                         blendMode: BlendMode.dstIn,
                         child: ConstrainedBox(
@@ -48,9 +47,9 @@ class ReviewsPreview extends StatelessWidget {
                               physics: const NeverScrollableScrollPhysics(),
                               child: Column(
                                 mainAxisSize: MainAxisSize.min,
-                                children: List.generate(
+                                children: List<ReviewDetail>.generate(
                                   min(reviews.length, 2),
-                                  (index) => ReviewDetail(review: reviews[index]),
+                                  (int index) => ReviewDetail(review: reviews[index]),
                                 ),
                               ),
                             ),
@@ -78,7 +77,9 @@ class ReviewsPreview extends StatelessWidget {
               color: Colors.transparent,
               child: InkWell(
                 onTap: () {
-                  Navigator.of(context).push(MaterialPageRoute(builder: (_) => ReviewsPage.fromProfile(profile)));
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(builder: (_) => ReviewsPage.fromProfile(profile)),
+                  );
                 },
               ),
             ),

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -77,13 +77,10 @@ class Drive extends Trip {
   List<Ride>? get approvedRides => rides?.where((Ride ride) => ride.status == RideStatus.approved).toList();
   List<Ride>? get pendingRides => rides?.where((Ride ride) => ride.status == RideStatus.pending).toList();
 
-  static Future<List<Drive>> getDrivesOfUser(int userId) async {
-    return Drive.fromJsonList(await SupabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId));
-  }
-
   static Future<bool> userHasDriveAtTimeRange(DateTimeRange range, int userId) async {
-    //get all upcoming drives of user
-    List<Drive> drives = await Drive.getDrivesOfUser(userId);
+    List<Map<String, dynamic>> data =
+        await SupabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId);
+    List<Drive> drives = Drive.fromJsonList(data);
     drives = drives.where((Drive drive) => !drive.cancelled && !drive.isFinished).toList();
 
     //check if drive overlaps with start and end

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../account/models/profile.dart';
 import '../../rides/models/ride.dart';
+import '../../util/parse_helper.dart';
 import '../../util/search/position.dart';
 import '../../util/supabase.dart';
 import '../../util/trip/trip.dart';
@@ -47,7 +48,7 @@ class Drive extends Trip {
       hideInListView: json['hide_in_list_view'],
       driverId: json['driver_id'],
       driver: json.containsKey('driver') ? Profile.fromJson(json['driver']) : null,
-      rides: json.containsKey('rides') ? Ride.fromJsonList(json['rides']) : null,
+      rides: json.containsKey('rides') ? Ride.fromJsonList(parseHelper.parseListOfMaps(json['rides'])) : null,
     );
   }
 

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -51,14 +51,14 @@ class Drive extends Trip {
     );
   }
 
-  static List<Drive> fromJsonList(List<dynamic> jsonList) {
-    return jsonList.map((json) => Drive.fromJson(json as Map<String, dynamic>)).toList();
+  static List<Drive> fromJsonList(List<Map<String, dynamic>> jsonList) {
+    return jsonList.map((Map<String, dynamic> json) => Drive.fromJson(json)).toList();
   }
 
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'cancelled': cancelled,
         'driver_id': driverId,
       });
@@ -67,14 +67,14 @@ class Drive extends Trip {
   @override
   Map<String, dynamic> toJsonForApi() {
     return super.toJsonForApi()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'driver': driver?.toJsonForApi(),
-        'rides': rides?.map((ride) => ride.toJsonForApi()).toList() ?? [],
+        'rides': rides?.map((Ride ride) => ride.toJsonForApi()).toList() ?? <Map<String, dynamic>>[],
       });
   }
 
-  List<Ride>? get approvedRides => rides?.where((ride) => ride.status == RideStatus.approved).toList();
-  List<Ride>? get pendingRides => rides?.where((ride) => ride.status == RideStatus.pending).toList();
+  List<Ride>? get approvedRides => rides?.where((Ride ride) => ride.status == RideStatus.approved).toList();
+  List<Ride>? get pendingRides => rides?.where((Ride ride) => ride.status == RideStatus.pending).toList();
 
   static Future<List<Drive>> getDrivesOfUser(int userId) async {
     return Drive.fromJsonList(await SupabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId));
@@ -83,7 +83,7 @@ class Drive extends Trip {
   static Future<bool> userHasDriveAtTimeRange(DateTimeRange range, int userId) async {
     //get all upcoming drives of user
     List<Drive> drives = await Drive.getDrivesOfUser(userId);
-    drives = drives.where((drive) => !drive.cancelled && !drive.isFinished).toList();
+    drives = drives.where((Drive drive) => !drive.cancelled && !drive.isFinished).toList();
 
     //check if drive overlaps with start and end
     for (Drive drive in drives) {
@@ -97,14 +97,17 @@ class Drive extends Trip {
   int? getMaxUsedSeats() {
     if (rides == null) return null;
 
-    Set<DateTime> times = approvedRides!.map((ride) => [ride.startTime, ride.endTime]).expand((x) => x).toSet();
+    Set<DateTime> times = approvedRides!
+        .map((Ride ride) => <DateTime>[ride.startTime, ride.endTime])
+        .expand((List<DateTime> x) => x)
+        .toSet();
 
     int maxUsedSeats = 0;
     for (DateTime time in times) {
       int usedSeats = 0;
       for (Ride ride in approvedRides!) {
-        final startTimeBeforeOrEqual = ride.startTime.isBefore(time) || ride.startTime.isAtSameMomentAs(time);
-        final endTimeAfter = ride.endTime.isAfter(time);
+        final bool startTimeBeforeOrEqual = ride.startTime.isBefore(time) || ride.startTime.isAtSameMomentAs(time);
+        final bool endTimeAfter = ride.endTime.isAfter(time);
         if (startTimeBeforeOrEqual && endTimeAfter) {
           usedSeats += ride.seats;
         }
@@ -118,17 +121,17 @@ class Drive extends Trip {
   }
 
   bool isRidePossible(Ride ride) {
-    List<Ride> consideredRides = approvedRides! + [ride];
+    List<Ride> consideredRides = approvedRides!..add(ride);
     Set<DateTime> times = consideredRides
-        .map((consideredRide) => [consideredRide.startTime, consideredRide.endTime])
-        .expand((x) => x)
+        .map((Ride consideredRide) => <DateTime>[consideredRide.startTime, consideredRide.endTime])
+        .expand((List<DateTime> x) => x)
         .toSet();
     for (DateTime time in times) {
       int usedSeats = 0;
       for (Ride consideredRide in consideredRides) {
-        final startTimeBeforeOrEqual =
+        final bool startTimeBeforeOrEqual =
             consideredRide.startTime.isBefore(time) || consideredRide.startTime.isAtSameMomentAs(time);
-        final endTimeAfter = consideredRide.endTime.isAfter(time);
+        final bool endTimeAfter = consideredRide.endTime.isAfter(time);
         if (startTimeBeforeOrEqual && endTimeAfter) {
           usedSeats += consideredRide.seats;
         }
@@ -143,7 +146,7 @@ class Drive extends Trip {
 
   Future<void> cancel() async {
     cancelled = true;
-    await SupabaseManager.supabaseClient.from('drives').update({'cancelled': true}).eq('id', id);
+    await SupabaseManager.supabaseClient.from('drives').update(<String, dynamic>{'cancelled': true}).eq('id', id);
     //the rides get updated automatically by a supabase function.
   }
 

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -78,8 +78,9 @@ class Drive extends Trip {
   List<Ride>? get pendingRides => rides?.where((Ride ride) => ride.status == RideStatus.pending).toList();
 
   static Future<bool> userHasDriveAtTimeRange(DateTimeRange range, int userId) async {
-    List<Map<String, dynamic>> data =
-        await SupabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId);
+    List<Map<String, dynamic>> data = parseHelper.parseListOfMaps(
+      await SupabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId),
+    );
     List<Drive> drives = Drive.fromJsonList(data);
     drives = drives.where((Drive drive) => !drive.cancelled && !drive.isFinished).toList();
 

--- a/lib/drives/pages/create_drive_page.dart
+++ b/lib/drives/pages/create_drive_page.dart
@@ -53,21 +53,21 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
   // ignore: unused_field
   AddressSuggestion? _destinationSuggestion;
 
-  final _dateController = TextEditingController();
-  final _timeController = TextEditingController();
+  final TextEditingController _dateController = TextEditingController();
+  final TextEditingController _timeController = TextEditingController();
   late DateTime _selectedDate;
   late int _dropdownValue;
 
-  final List<int> list = List.generate(10, (index) => index + 1);
+  final List<int> list = List<int>.generate(10, (int index) => index + 1);
 
   void _showTimePicker() {
     showTimePicker(
       context: context,
       initialTime: TimeOfDay(hour: _selectedDate.hour, minute: _selectedDate.minute),
-      builder: (context, childWidget) {
+      builder: (BuildContext context, Widget? childWidget) {
         return MediaQuery(data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true), child: childWidget!);
       },
-    ).then((value) {
+    ).then((TimeOfDay? value) {
       setState(() {
         if (value != null) {
           _selectedDate =
@@ -86,7 +86,7 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
       initialDate: _selectedDate,
       firstDate: firstDate,
       lastDate: firstDate.add(const Duration(days: 30)),
-    ).then((value) {
+    ).then((DateTime? value) {
       setState(() {
         if (value != null) {
           _selectedDate = DateTime(value.year, value.month, value.day, _selectedDate.hour, _selectedDate.minute);
@@ -138,11 +138,11 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
             .select<Map<String, dynamic>>()
             .single()
             .then(
-          (data) {
+          (Map<String, dynamic> data) {
             Drive drive = Drive.fromJson(data);
             Navigator.pushReplacement(
               context,
-              MaterialPageRoute(
+              MaterialPageRoute<void>(
                 builder: (BuildContext context) => DriveDetailPage.fromDrive(drive),
               ),
             );
@@ -192,21 +192,21 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
     return Form(
       key: _formKey,
       child: Column(
-        children: [
+        children: <Widget>[
           AddressSearchField.start(
             controller: _startController,
-            onSelected: (suggestion) => _startSuggestion = suggestion,
+            onSelected: (AddressSuggestion suggestion) => _startSuggestion = suggestion,
           ),
           const SizedBox(height: 15),
           AddressSearchField.destination(
             controller: _destinationController,
-            onSelected: (suggestion) => _destinationSuggestion = suggestion,
+            onSelected: (AddressSuggestion suggestion) => _destinationSuggestion = suggestion,
           ),
           Container(
             padding: const EdgeInsets.symmetric(vertical: 15),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
+              children: <Widget>[
                 Expanded(
                   child: Semantics(
                     button: true,

--- a/lib/drives/pages/drive_chat_page.dart
+++ b/lib/drives/pages/drive_chat_page.dart
@@ -30,9 +30,9 @@ class _DriveChatPageState extends State<DriveChatPage> {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> widgets = [];
+    List<Widget> widgets = <Widget>[];
     if (_fullyLoaded) {
-      Set<Profile> riders = _drive!.approvedRides!.map((ride) => ride.rider!).toSet();
+      Set<Profile> riders = _drive!.approvedRides!.map((Ride ride) => ride.rider!).toSet();
       List<Ride> pendingRides = _drive!.pendingRides!.toList();
       if (riders.isEmpty && pendingRides.isEmpty) {
         return Scaffold(
@@ -45,7 +45,7 @@ class _DriveChatPageState extends State<DriveChatPage> {
         );
       } else {
         if (riders.isNotEmpty) {
-          List<Widget> riderColumn = [
+          List<Widget> riderColumn = <Widget>[
             const SizedBox(height: 5.0),
             Text(
               S.of(context).pageDriveChatRiderHeadline,
@@ -70,7 +70,7 @@ class _DriveChatPageState extends State<DriveChatPage> {
         onRefresh: loadDrive,
         child: ListView.separated(
           itemCount: widgets.length,
-          itemBuilder: (context, index) {
+          itemBuilder: (BuildContext context, int index) {
             return widgets[index];
           },
           separatorBuilder: (BuildContext context, int index) {
@@ -85,9 +85,9 @@ class _DriveChatPageState extends State<DriveChatPage> {
     Widget ridersColumn = Container();
     if (riders.isNotEmpty) {
       ridersColumn = Column(
-        children: List.generate(
+        children: List<Padding>.generate(
           riders.length,
-          (index) => Padding(
+          (int index) => Padding(
             padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 5.0),
             child: ProfileWidget(
               riders.elementAt(index),

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -62,7 +62,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> widgets = [];
+    List<Widget> widgets = <Widget>[];
 
     if (_drive != null) {
       widgets.add(TripOverview(_drive!));
@@ -72,14 +72,14 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
     if (_fullyLoaded) {
       Drive drive = _drive!;
 
-      List<Waypoint> stops = [];
+      List<Waypoint> stops = <Waypoint>[];
       stops.add(Waypoint(
-        actions: [],
+        actions: <WaypointAction>[],
         place: drive.start,
         time: drive.startTime,
       ));
       stops.add(Waypoint(
-        actions: [],
+        actions: <WaypointAction>[],
         place: drive.end,
         time: drive.endTime,
       ));
@@ -102,7 +102,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
         if (!startSaved) {
           stops.add(Waypoint(
-            actions: [rideStartAction],
+            actions: <WaypointAction>[rideStartAction],
             place: ride.start,
             time: ride.startTime,
           ));
@@ -110,30 +110,30 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
         if (!endSaved) {
           stops.add(Waypoint(
-            actions: [rideEndAction],
+            actions: <WaypointAction>[rideEndAction],
             place: ride.end,
             time: ride.endTime,
           ));
         }
       }
 
-      stops.sort((a, b) => a.time.compareTo(b.time));
+      stops.sort((Waypoint a, Waypoint b) => a.time.compareTo(b.time));
       for (Waypoint stop in stops) {
-        stop.actions.sort((a, b) => a.isStart ? 1 : -1);
+        stop.actions.sort((WaypointAction a, WaypointAction b) => a.isStart ? 1 : -1);
       }
 
       Widget timeline = FixedTimeline.tileBuilder(
         theme: CustomTimelineThemeForBuilder.of(context),
         builder: TimelineTileBuilder.connected(
           connectionDirection: ConnectionDirection.before,
-          indicatorBuilder: (context, index) => const CustomOutlinedDotIndicator(),
-          connectorBuilder: (context, index, type) => const CustomSolidLineConnector(),
-          contentsBuilder: (context, index) {
-            final stop = stops[index];
+          indicatorBuilder: (BuildContext context, int index) => const CustomOutlinedDotIndicator(),
+          connectorBuilder: (BuildContext context, int index, ConnectorType type) => const CustomSolidLineConnector(),
+          contentsBuilder: (BuildContext context, int index) {
+            final Waypoint stop = stops[index];
             return Padding(
               padding: const EdgeInsets.only(left: 8.0),
               child: Column(
-                children: [
+                children: <Widget>[
                   const SizedBox(height: 10.0),
                   Container(
                     decoration: BoxDecoration(
@@ -160,13 +160,13 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
       if (approvedRides.isNotEmpty) {
         widgets.add(const Divider(thickness: 1));
-        Set<Profile> riders = approvedRides.map((ride) => ride.rider!).toSet();
+        Set<Profile> riders = approvedRides.map((Ride ride) => ride.rider!).toSet();
         widgets.add(ProfileWrapList(riders, title: S.of(context).riders));
       }
 
       List<Ride> pendingRides = _drive!.pendingRides!.toList();
       if (pendingRides.isNotEmpty) {
-        List<Widget> pendingRidesColumn = [
+        List<Widget> pendingRidesColumn = <Widget>[
           const SizedBox(height: 5.0),
           Align(
             alignment: Alignment.centerLeft,
@@ -204,7 +204,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
     }
 
     Widget content = Column(
-      children: [
+      children: <Widget>[
         if (_drive?.cancelled ?? false)
           CustomBanner.error(
             S.of(context).pageDriveDetailBannerCancelled,
@@ -223,7 +223,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(S.of(context).pageDriveDetailTitle),
-        actions: [buildChatButton()],
+        actions: <Widget>[buildChatButton()],
       ),
       body: _drive == null
           ? const Center(child: CircularProgressIndicator())
@@ -253,12 +253,12 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
       key: const Key('driveChatButton'),
       onPressed: () => Navigator.push(
         context,
-        MaterialPageRoute(
-          builder: (context) => DriveChatPage(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => DriveChatPage(
             drive: _drive!,
           ),
         ),
-      ).then((value) => loadDrive()),
+      ).then((_) => loadDrive()),
       icon: Badge(
         badgeContent: Text(
           _getMessageCount(_drive!).toString(),
@@ -274,14 +274,14 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   List<Widget> buildCard(Waypoint stop) {
-    List<Widget> list = [];
+    List<Widget> list = <Widget>[];
     list.add(
       MergeSemantics(
         child: Padding(
           padding: const EdgeInsets.only(bottom: 4),
           child: Row(
             mainAxisSize: MainAxisSize.min,
-            children: [
+            children: <Widget>[
               Text(
                 localeManager.formatTime(stop.time),
                 style: Theme.of(context).textTheme.labelLarge!.copyWith(fontWeight: FontWeight.w700),
@@ -296,12 +296,12 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
       ),
     );
 
-    final startIcon = Icon(Icons.north_east_rounded, color: Theme.of(context).own().success);
-    final endIcon = Icon(Icons.south_west_rounded, color: Theme.of(context).colorScheme.error);
+    final Icon startIcon = Icon(Icons.north_east_rounded, color: Theme.of(context).own().success);
+    final Icon endIcon = Icon(Icons.south_west_rounded, color: Theme.of(context).colorScheme.error);
     for (int index = 0, length = stop.actions.length; index < length; index++) {
-      final action = stop.actions[index];
-      final icon = action.isStart ? startIcon : endIcon;
-      final profile = action.profile;
+      final WaypointAction action = stop.actions[index];
+      final Icon icon = action.isStart ? startIcon : endIcon;
+      final Profile profile = action.profile;
 
       Widget container = Semantics(
         button: true,
@@ -324,7 +324,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                 padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 10.0),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
+                  children: <Widget>[
                     Expanded(
                       child: Align(
                         alignment: Alignment.centerLeft,
@@ -360,13 +360,15 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   void hideDrive() async {
-    await SupabaseManager.supabaseClient.from('drives').update({'hide_in_list_view': true}).eq('id', widget.drive!.id);
+    await SupabaseManager.supabaseClient
+        .from('drives')
+        .update(<String, dynamic>{'hide_in_list_view': true}).eq('id', widget.drive!.id);
   }
 
   void _showHideDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
+      builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageDriveDetailButtonHide),
         content: Text(S.of(context).pageDriveDetailHideDialog),
         actions: <Widget>[
@@ -397,7 +399,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   void _showCancelDialog() {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
+      builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).pageDriveDetailCancelDialogTitle),
         content: Text(S.of(context).pageDriveDetailCancelDialogMessage),
         actions: <Widget>[
@@ -431,11 +433,11 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   List<Widget> _pendingRidesList(List<Ride> pendingRides) {
-    List<Widget> pendingRidesColumn = [];
+    List<Widget> pendingRidesColumn = <Widget>[];
     if (pendingRides.isNotEmpty) {
-      pendingRidesColumn = List.generate(
+      pendingRidesColumn = List<PendingRideCard>.generate(
         pendingRides.length,
-        (index) => PendingRideCard(
+        (int index) => PendingRideCard(
           pendingRides.elementAt(index),
           reloadPage: loadDrive,
           drive: _drive!,

--- a/lib/drives/pages/drives_page.dart
+++ b/lib/drives/pages/drives_page.dart
@@ -22,10 +22,10 @@ class _DrivesPageState extends State<DrivesPage> {
     int userId = SupabaseManager.getCurrentProfile()!.id!;
     _drives = SupabaseManager.supabaseClient
         .from('drives')
-        .stream(primaryKey: ['id'])
+        .stream(primaryKey: <String>['id'])
         .eq('driver_id', userId)
         .order('start_time', ascending: true)
-        .map((drive) => Drive.fromJsonList(drive));
+        .map((List<Map<String, dynamic>> drive) => Drive.fromJsonList(drive));
 
     super.initState();
   }
@@ -36,7 +36,7 @@ class _DrivesPageState extends State<DrivesPage> {
       context,
       S.of(context).pageDrivesTitle,
       _drives,
-      (drive) => DriveCard(drive),
+      (Drive drive) => DriveCard(drive),
       FloatingActionButton(
         heroTag: 'DriveFAB',
         tooltip: S.of(context).pageDrivesTooltipOfferRide,
@@ -49,7 +49,7 @@ class _DrivesPageState extends State<DrivesPage> {
 
   void onPressed() {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => const CreateDrivePage()),
+      MaterialPageRoute<void>(builder: (BuildContext context) => const CreateDrivePage()),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,7 @@ class _AppWrapperState extends State<AppWrapper> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      onGenerateTitle: (context) => S.of(context).appName,
+      onGenerateTitle: (BuildContext context) => S.of(context).appName,
       debugShowCheckedModeBanner: false,
       theme: themeManager.lightTheme,
       darkTheme: themeManager.darkTheme,
@@ -85,7 +85,7 @@ class _AuthAppState extends State<AuthApp> {
 
   void _setupAuthStateSubscription() {
     _authStateSubscription = SupabaseManager.supabaseClient.auth.onAuthStateChange.listen(
-      (data) async {
+      (AuthState data) async {
         final AuthChangeEvent event = data.event;
         final Session? session = data.session;
         await SupabaseManager.reloadCurrentProfile();
@@ -98,11 +98,11 @@ class _AuthAppState extends State<AuthApp> {
               event == AuthChangeEvent.signedIn ||
               event == AuthChangeEvent.passwordRecovery ||
               event == AuthChangeEvent.userDeleted) {
-            Navigator.of(context).popUntil((route) => route.isFirst);
+            Navigator.of(context).popUntil((Route<void> route) => route.isFirst);
           }
         });
       },
-      onError: (error) {
+      onError: (Object error) {
         if (error.runtimeType == AuthException) {
           error = error as AuthException;
           if (error.message == 'Email link is invalid or has expired') {

--- a/lib/main_app.dart
+++ b/lib/main_app.dart
@@ -17,13 +17,13 @@ class MainApp extends StatefulWidget {
 
 class _MainAppState extends State<MainApp> {
   TabItem _currentTab = TabItem.home;
-  final _navigatorKeys = {
+  final Map<TabItem, GlobalKey<NavigatorState>> _navigatorKeys = <TabItem, GlobalKey<NavigatorState>>{
     TabItem.home: GlobalKey<NavigatorState>(),
     TabItem.drives: GlobalKey<NavigatorState>(),
     TabItem.rides: GlobalKey<NavigatorState>(),
     TabItem.account: GlobalKey<NavigatorState>(),
   };
-  final _pages = {
+  final Map<TabItem, Widget> _pages = <TabItem, Widget>{
     TabItem.home: const HomePage(),
     TabItem.drives: const DrivesPage(),
     TabItem.rides: const RidesPage(),
@@ -33,7 +33,7 @@ class _MainAppState extends State<MainApp> {
   void _selectTab(TabItem tabItem) {
     if (tabItem == _currentTab) {
       // pop to first route
-      _navigatorKeys[tabItem]!.currentState!.popUntil((route) => route.isFirst);
+      _navigatorKeys[tabItem]!.currentState!.popUntil((Route<void> route) => route.isFirst);
     } else {
       setState(() => _currentTab = tabItem);
     }
@@ -43,7 +43,7 @@ class _MainAppState extends State<MainApp> {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
-        final isFirstRouteInCurrentTab = !await _navigatorKeys[_currentTab]!.currentState!.maybePop();
+        final bool isFirstRouteInCurrentTab = !await _navigatorKeys[_currentTab]!.currentState!.maybePop();
         if (isFirstRouteInCurrentTab) {
           if (_currentTab == TabItem.home) {
             return true;
@@ -56,7 +56,7 @@ class _MainAppState extends State<MainApp> {
       child: Scaffold(
         body: IndexedStack(
           index: _currentTab.index,
-          children: TabItem.values.map((tabItem) => buildNavigatorForTab(tabItem)).toList(),
+          children: TabItem.values.map((TabItem tabItem) => buildNavigatorForTab(tabItem)).toList(),
         ),
         bottomNavigationBar: BottomNavigationBar(
           type: BottomNavigationBarType.fixed,
@@ -80,7 +80,7 @@ class _MainAppState extends State<MainApp> {
           ],
           currentIndex: _currentTab.index,
           selectedItemColor: Theme.of(context).colorScheme.primary,
-          onTap: (index) {
+          onTap: (int index) {
             _selectTab(TabItem.values[index]);
           },
         ),
@@ -91,8 +91,8 @@ class _MainAppState extends State<MainApp> {
   Widget buildNavigatorForTab(TabItem tabItem) {
     return Navigator(
       key: _navigatorKeys[tabItem]!,
-      onGenerateRoute: (routeSettings) => MaterialPageRoute(
-        builder: (context) => _pages[tabItem]!,
+      onGenerateRoute: (RouteSettings routeSettings) => MaterialPageRoute<void>(
+        builder: (BuildContext context) => _pages[tabItem]!,
       ),
     );
   }

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -111,8 +111,9 @@ class Ride extends Trip {
   }
 
   static Future<bool> userHasRideAtTimeRange(DateTimeRange range, int userId) async {
-    List<Map<String, dynamic>> jsonList =
-        await SupabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId);
+    List<Map<String, dynamic>> jsonList = parseHelper.parseListOfMaps(
+      await SupabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId),
+    );
     List<Ride> rides =
         Ride.fromJsonList(jsonList).where((Ride ride) => ride.status.isApproved() && !ride.isFinished).toList();
 

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -86,14 +86,14 @@ class Ride extends Trip {
     );
   }
 
-  static List<Ride> fromJsonList(List<dynamic> jsonList) {
-    return jsonList.map((json) => Ride.fromJson(json as Map<String, dynamic>)).toList();
+  static List<Ride> fromJsonList(List<Map<String, dynamic>> jsonList) {
+    return jsonList.map((Map<String, dynamic> json) => Ride.fromJson(json)).toList();
   }
 
   @override
   Map<String, dynamic> toJson() {
     return super.toJson()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'price': price,
         'status': status.index,
         'drive_id': driveId,
@@ -104,7 +104,7 @@ class Ride extends Trip {
   @override
   Map<String, dynamic> toJsonForApi() {
     return super.toJsonForApi()
-      ..addAll({
+      ..addAll(<String, dynamic>{
         'drive': drive?.toJsonForApi(),
         'rider': rider?.toJsonForApi(),
       });
@@ -113,7 +113,7 @@ class Ride extends Trip {
   static Future<bool> userHasRideAtTimeRange(DateTimeRange range, int userId) async {
     //get all approved and upcoming rides of user
     List<Ride> rides = await getRidesOfUser(userId);
-    rides = rides.where((ride) => ride.status.isApproved() && !ride.isFinished).toList();
+    rides = rides.where((Ride ride) => ride.status.isApproved() && !ride.isFinished).toList();
 
     //check if ride overlaps with start and end
     for (Ride ride in rides) {
@@ -160,14 +160,14 @@ class Ride extends Trip {
 
   Future<void> cancel() async {
     status = RideStatus.cancelledByRider;
-    await SupabaseManager.supabaseClient.from('rides').update({'status': status.index}).eq('id', id);
+    await SupabaseManager.supabaseClient.from('rides').update(<String, dynamic>{'status': status.index}).eq('id', id);
   }
 
   Future<void> withdraw() async {
     status = RideStatus.withdrawnByRider;
     await SupabaseManager.supabaseClient
         .from('rides')
-        .update({'status': status.index, 'hide_in_list_view': true}).eq('id', id);
+        .update(<String, dynamic>{'status': status.index, 'hide_in_list_view': true}).eq('id', id);
   }
 
   @override

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -111,9 +111,10 @@ class Ride extends Trip {
   }
 
   static Future<bool> userHasRideAtTimeRange(DateTimeRange range, int userId) async {
-    //get all approved and upcoming rides of user
-    List<Ride> rides = await getRidesOfUser(userId);
-    rides = rides.where((Ride ride) => ride.status.isApproved() && !ride.isFinished).toList();
+    List<Map<String, dynamic>> jsonList =
+        await SupabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId);
+    List<Ride> rides =
+        Ride.fromJsonList(jsonList).where((Ride ride) => ride.status.isApproved() && !ride.isFinished).toList();
 
     //check if ride overlaps with start and end
     for (Ride ride in rides) {
@@ -122,10 +123,6 @@ class Ride extends Trip {
       }
     }
     return false;
-  }
-
-  static Future<List<Ride>> getRidesOfUser(int userId) async {
-    return Ride.fromJsonList(await SupabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId));
   }
 
   @override

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -89,7 +89,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> widgets = [];
+    List<Widget> widgets = <Widget>[];
 
     if (_ride != null) {
       widgets.add(TripOverview(_ride!));
@@ -111,8 +111,10 @@ class _RideDetailPageState extends State<RideDetailPage> {
       if (ride.status == RideStatus.approved || ride.status == RideStatus.cancelledByDriver) {
         widgets.add(const Divider(thickness: 1));
 
-        Set<Profile> riders =
-            ride.drive!.rides!.where((otherRide) => ride.overlapsWith(otherRide)).map((ride) => ride.rider!).toSet();
+        Set<Profile> riders = ride.drive!.rides!
+            .where((Ride otherRide) => ride.overlapsWith(otherRide))
+            .map((Ride ride) => ride.rider!)
+            .toSet();
         widgets.add(ProfileWrapList(riders, title: S.of(context).riders));
       }
 
@@ -128,7 +130,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
     }
 
     Widget content = Column(
-      children: [
+      children: <Widget>[
         if (_ride != null && _ride!.status == RideStatus.pending)
           CustomBanner.warning(S.of(context).pageRideDetailBannerRequested)
         else if (_ride != null && _ride!.status == RideStatus.rejected)
@@ -201,16 +203,14 @@ class _RideDetailPageState extends State<RideDetailPage> {
 
   void _navigateToRatePage(Profile driver) {
     Navigator.of(context)
-        .push(
-          MaterialPageRoute(builder: (context) => WriteReviewPage(driver)),
-        )
-        .then((value) => loadRide());
+        .push(MaterialPageRoute<void>(builder: (BuildContext context) => WriteReviewPage(driver)))
+        .then((_) => loadRide());
   }
 
   void _showCancelDialog() {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
+      builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).pageRideDetailCancelDialogTitle),
         content: Text(S.of(context).pageRideDetailCancelDialogMessage),
         actions: <Widget>[
@@ -245,7 +245,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   void _showRequestDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
+      builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageRideDetailRequestDialogTitle),
         content: Text(S.of(context).pageRideDetailRequestDialogMessage),
         actions: <Widget>[
@@ -266,13 +266,15 @@ class _RideDetailPageState extends State<RideDetailPage> {
   }
 
   void hideRide() async {
-    await SupabaseManager.supabaseClient.from('rides').update({'hide_in_list_view': true}).eq('id', widget.ride!.id);
+    await SupabaseManager.supabaseClient
+        .from('rides')
+        .update(<String, dynamic>{'hide_in_list_view': true}).eq('id', widget.ride!.id);
   }
 
-  _showHideDialog() {
+  void _showHideDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
+      builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageRideDetailButtonHide),
         content: Text(S.of(context).pageRideDetailHideDialog),
         actions: <Widget>[
@@ -295,7 +297,8 @@ class _RideDetailPageState extends State<RideDetailPage> {
 
   void confirmRequest(Ride ride) async {
     ride.status = RideStatus.pending;
-    final data = await SupabaseManager.supabaseClient.from('rides').insert(ride.toJson()).select(_rideQuery).single();
+    Map<String, dynamic> data =
+        await SupabaseManager.supabaseClient.from('rides').insert(ride.toJson()).select(_rideQuery).single();
     setState(() {
       _ride = Ride.fromJson(data);
     });
@@ -305,7 +308,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   void _showWithdrawDialog() {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
+      builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).pageRideDetailWithdrawDialogTitle),
         content: Text(S.of(context).pageRideDetailWithdrawDialogMessage),
         actions: <Widget>[
@@ -340,7 +343,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   void _showLoginDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
+      builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageRideDetailLoginDialogTitle),
         content: Text(S.of(context).pageRideDetailLoginDialogMessage),
         actions: <Widget>[
@@ -352,15 +355,15 @@ class _RideDetailPageState extends State<RideDetailPage> {
               child: Text(S.of(context).pageWelcomeLogin),
               onPressed: () {
                 Navigator.of(dialogContext).pop();
-                Navigator.popUntil(context, (route) => route.isFirst);
-                Navigator.push(context, MaterialPageRoute(builder: (context) => const LoginPage()));
+                Navigator.popUntil(context, (Route<void> route) => route.isFirst);
+                Navigator.push(context, MaterialPageRoute<void>(builder: (BuildContext context) => const LoginPage()));
               }),
           TextButton(
             child: Text(S.of(context).pageWelcomeRegister),
             onPressed: () {
               Navigator.of(context).pop();
-              Navigator.popUntil(context, (route) => route.isFirst);
-              Navigator.push(context, MaterialPageRoute(builder: (context) => const RegisterPage()));
+              Navigator.popUntil(context, (Route<void> route) => route.isFirst);
+              Navigator.push(context, MaterialPageRoute<void>(builder: (BuildContext context) => const RegisterPage()));
             },
           ),
         ],

--- a/lib/rides/pages/rides_page.dart
+++ b/lib/rides/pages/rides_page.dart
@@ -23,20 +23,20 @@ class _RidesPageState extends State<RidesPage> {
     int userId = SupabaseManager.getCurrentProfile()!.id!;
     _rides = SupabaseManager.supabaseClient
         .from('rides')
-        .stream(primaryKey: ['id'])
+        .stream(primaryKey: <String>['id'])
         .eq('rider_id', userId)
         .order('start_time', ascending: true)
-        .map((ride) => Ride.fromJsonList(ride));
+        .map((List<Map<String, dynamic>> ride) => Ride.fromJsonList(ride));
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     return TripPageBuilder.build(
-      context, //context
-      S.of(context).pageRidesTitle, //title
-      _rides, //trips
-      (ride) => RideCard(ride),
+      context,
+      S.of(context).pageRidesTitle,
+      _rides,
+      (Ride ride) => RideCard(ride),
       FloatingActionButton(
         heroTag: 'RideFAB',
         tooltip: S.of(context).pageRidesTooltipSearchRide,
@@ -49,7 +49,7 @@ class _RidesPageState extends State<RidesPage> {
 
   void searchRide() {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => const SearchRidePage()),
+      MaterialPageRoute<void>(builder: (BuildContext context) => const SearchRidePage()),
     );
   }
 }

--- a/lib/rides/pages/search_ride_page.dart
+++ b/lib/rides/pages/search_ride_page.dart
@@ -56,12 +56,12 @@ class _SearchRideFormState extends State<SearchRideForm> {
   final TextEditingController _destinationController = TextEditingController();
   late AddressSuggestion? _destinationSuggestion;
 
-  final _dateController = TextEditingController();
-  final _timeController = TextEditingController();
+  final TextEditingController _dateController = TextEditingController();
+  final TextEditingController _timeController = TextEditingController();
   late DateTime _selectedDate;
   late int _dropdownValue;
 
-  final List<int> list = List.generate(10, (index) => index + 1);
+  final List<int> list = List<int>.generate(10, (int index) => index + 1);
 
   @override
   void initState() {
@@ -83,10 +83,10 @@ class _SearchRideFormState extends State<SearchRideForm> {
     showTimePicker(
       context: context,
       initialTime: TimeOfDay(hour: _selectedDate.hour, minute: _selectedDate.minute),
-      builder: (context, childWidget) {
+      builder: (BuildContext context, Widget? childWidget) {
         return MediaQuery(data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true), child: childWidget!);
       },
-    ).then((value) {
+    ).then((TimeOfDay? value) {
       setState(() {
         if (value != null) {
           _selectedDate =
@@ -105,7 +105,7 @@ class _SearchRideFormState extends State<SearchRideForm> {
       initialDate: _selectedDate,
       firstDate: firstDate,
       lastDate: firstDate.add(const Duration(days: 30)),
-    ).then((value) {
+    ).then((DateTime? value) {
       setState(() {
         if (value != null) {
           _selectedDate = DateTime(value.year, value.month, value.day, _selectedDate.hour, _selectedDate.minute);
@@ -128,8 +128,8 @@ class _SearchRideFormState extends State<SearchRideForm> {
   void _onSubmit() async {
     if (_formKey.currentState!.validate()) {
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(
-          builder: (context) => SearchSuggestionPage(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => SearchSuggestionPage(
             _startSuggestion!,
             _destinationSuggestion!,
             _selectedDate,
@@ -218,17 +218,17 @@ class _SearchRideFormState extends State<SearchRideForm> {
       child: Padding(
         padding: const EdgeInsets.fromLTRB(10, 20, 10, 0),
         child: Column(
-          children: [
+          children: <Widget>[
             AddressSearchField.start(
               controller: _startController,
-              onSelected: (suggestion) {
+              onSelected: (AddressSuggestion suggestion) {
                 _startSuggestion = suggestion;
               },
             ),
             const SizedBox(height: 15),
             AddressSearchField.destination(
               controller: _destinationController,
-              onSelected: (suggestion) {
+              onSelected: (AddressSuggestion suggestion) {
                 _destinationSuggestion = suggestion;
               },
             ),
@@ -236,7 +236,7 @@ class _SearchRideFormState extends State<SearchRideForm> {
               padding: const EdgeInsets.symmetric(vertical: 15),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
+                children: <Widget>[
                   buildDatePicker(),
                   buildTimePicker(),
                   const SizedBox(width: 50),

--- a/lib/rides/pages/search_suggestion_page.dart
+++ b/lib/rides/pages/search_suggestion_page.dart
@@ -30,12 +30,12 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
   final TextEditingController _destinationController = TextEditingController();
   late AddressSuggestion _destinationSuggestion;
 
-  final _dateController = TextEditingController();
-  final _timeController = TextEditingController();
+  final TextEditingController _dateController = TextEditingController();
+  final TextEditingController _timeController = TextEditingController();
   late DateTime _selectedDate;
   late int _dropdownValue;
 
-  final List<int> list = List.generate(10, (index) => index + 1);
+  final List<int> list = List<int>.generate(10, (int index) => index + 1);
 
   final SearchSuggestionFilter _filter = SearchSuggestionFilter();
 
@@ -71,7 +71,7 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
       initialDate: _selectedDate,
       firstDate: firstDate,
       lastDate: firstDate.add(const Duration(days: 30)),
-    ).then((value) {
+    ).then((DateTime? value) {
       if (value != null) {
         setState(() {
           _selectedDate = DateTime(value.year, value.month, value.day, _selectedDate.hour, _selectedDate.minute);
@@ -86,10 +86,10 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
     showTimePicker(
       context: context,
       initialTime: TimeOfDay(hour: _selectedDate.hour, minute: _selectedDate.minute),
-      builder: (context, childWidget) {
+      builder: (BuildContext context, Widget? childWidget) {
         return MediaQuery(data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true), child: childWidget!);
       },
-    ).then((value) {
+    ).then((TimeOfDay? value) {
       if (value != null) {
         setState(() {
           _selectedDate =
@@ -113,7 +113,7 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
 
   //todo: get possible Rides from Algorithm
   Future<void> loadRides() async {
-    List<dynamic> data = await SupabaseManager.supabaseClient.from('drives').select('''
+    List<Map<String, dynamic>> data = await SupabaseManager.supabaseClient.from('drives').select('''
           *,
           driver:driver_id (
             *,
@@ -121,9 +121,9 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
             reviews_received: reviews!reviews_receiver_id_fkey(*)
           )
         ''').eq('start', _startController.text);
-    List<Drive> drives = data.map((drive) => Drive.fromJson(drive)).toList();
+    List<Drive> drives = data.map((Map<String, dynamic> drive) => Drive.fromJson(drive)).toList();
     List<Ride> rides = drives
-        .map((drive) => Ride.previewFromDrive(
+        .map((Drive drive) => Ride.previewFromDrive(
               drive,
               _startSuggestion.name,
               _startSuggestion.position,
@@ -142,7 +142,7 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
   }
 
   FixedTimeline buildSearchFieldViewer() {
-    return FixedTimeline(theme: CustomTimelineTheme.of(context), children: [
+    return FixedTimeline(theme: CustomTimelineTheme.of(context), children: <Widget>[
       TimelineTile(
         contents: Padding(
           padding: const EdgeInsets.all(4.0),
@@ -268,7 +268,7 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
         child: SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           child: Column(
-            children: [
+            children: <Widget>[
               Image.asset('assets/shrug.png'),
               Text(
                 S.of(context).pageSearchSuggestionsEmpty,
@@ -297,8 +297,8 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
       );
     } else {
       list = ListView.separated(
-        itemBuilder: (context, index) {
-          final ride = filteredSuggestions[index];
+        itemBuilder: (BuildContext context, int index) {
+          final Ride ride = filteredSuggestions[index];
           return RideCard(ride);
         },
         separatorBuilder: (BuildContext context, int index) {
@@ -315,7 +315,7 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
   Widget buildDateSeatsRow() {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
+      children: <Widget>[
         buildDatePicker(),
         buildTimePicker(),
         const SizedBox(width: 50),
@@ -331,7 +331,7 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
       body: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
-          children: [
+          children: <Widget>[
             buildSearchFieldViewer(),
             const SizedBox(height: 10),
             buildDateSeatsRow(),

--- a/lib/rides/pages/search_suggestion_page.dart
+++ b/lib/rides/pages/search_suggestion_page.dart
@@ -5,6 +5,7 @@ import 'package:timelines/timelines.dart';
 import '../../drives/models/drive.dart';
 import '../../util/custom_timeline_theme.dart';
 import '../../util/locale_manager.dart';
+import '../../util/parse_helper.dart';
 import '../../util/search/address_search_delegate.dart';
 import '../../util/search/address_suggestion.dart';
 import '../../util/supabase.dart';
@@ -113,14 +114,16 @@ class _SearchSuggestionPage extends State<SearchSuggestionPage> {
 
   //todo: get possible Rides from Algorithm
   Future<void> loadRides() async {
-    List<Map<String, dynamic>> data = await SupabaseManager.supabaseClient.from('drives').select('''
+    List<Map<String, dynamic>> data = parseHelper.parseListOfMaps(
+      await SupabaseManager.supabaseClient.from('drives').select('''
           *,
           driver:driver_id (
             *,
             profile_features (*),
             reviews_received: reviews!reviews_receiver_id_fkey(*)
           )
-        ''').eq('start', _startController.text);
+        ''').eq('start', _startController.text),
+    );
     List<Drive> drives = data.map((Map<String, dynamic> drive) => Drive.fromJson(drive)).toList();
     List<Ride> rides = drives
         .map((Drive drive) => Ride.previewFromDrive(

--- a/lib/rides/widgets/search_suggestion_filter.dart
+++ b/lib/rides/widgets/search_suggestion_filter.dart
@@ -12,7 +12,7 @@ import '../../util/profiles/reviews/custom_rating_bar_size.dart';
 import '../models/ride.dart';
 
 class SearchSuggestionFilter {
-  static const List<Feature> _commonFeatures = [
+  static const List<Feature> _commonFeatures = <Feature>[
     Feature.noSmoking,
     Feature.noVaping,
     Feature.petsAllowed,
@@ -21,7 +21,7 @@ class SearchSuggestionFilter {
     Feature.relaxedDrivingStyle,
   ];
   static const int _defaultRating = 1;
-  static const List<Feature> _defaultFeatures = [];
+  static const List<Feature> _defaultFeatures = <Feature>[];
   static const SearchSuggestionSorting _defaultSorting = SearchSuggestionSorting.relevance;
   static const String _defaultDeviation = "12";
 
@@ -36,17 +36,17 @@ class SearchSuggestionFilter {
   late int _minHospitalityRating;
   late List<Feature> _selectedFeatures;
   late SearchSuggestionSorting _sorting;
-  final _maxDeviationController = TextEditingController();
+  final TextEditingController _maxDeviationController = TextEditingController();
 
   void setDefaultFilterValues() {
-    _retractedAdditionalFeatures = [..._commonFeatures];
+    _retractedAdditionalFeatures = <Feature>[..._commonFeatures];
 
     _minRating = _defaultRating;
     _minComfortRating = _defaultRating;
     _minSafetyRating = _defaultRating;
     _minReliabilityRating = _defaultRating;
     _minHospitalityRating = _defaultRating;
-    _selectedFeatures = [..._defaultFeatures];
+    _selectedFeatures = <Feature>[..._defaultFeatures];
     _maxDeviationController.text = _defaultDeviation;
     _sorting = _defaultSorting;
   }
@@ -58,7 +58,7 @@ class SearchSuggestionFilter {
   Widget _filterCategory(BuildContext context, String title, Widget content) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
+      children: <Widget>[
         Text(
           title,
           style: Theme.of(context).textTheme.titleLarge,
@@ -74,20 +74,20 @@ class SearchSuggestionFilter {
       S.of(context).searchSuggestionsFilterMinimumRating,
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+        children: <Widget>[
           CustomRatingBar(
             size: CustomRatingBarSize.large,
             rating: _minRating,
-            onRatingUpdate: (newRating) => innerSetState(
+            onRatingUpdate: (double newRating) => innerSetState(
               () => _minRating = newRating.toInt(),
             ),
           ),
-          if (_isRatingExpanded) ...[
+          if (_isRatingExpanded) ...<Widget>[
             Text(S.of(context).reviewCategoryComfort),
             CustomRatingBar(
               size: CustomRatingBarSize.medium,
               rating: _minComfortRating,
-              onRatingUpdate: (newRating) => innerSetState(
+              onRatingUpdate: (double newRating) => innerSetState(
                 () => _minComfortRating = newRating.toInt(),
               ),
             ),
@@ -95,7 +95,7 @@ class SearchSuggestionFilter {
             CustomRatingBar(
               size: CustomRatingBarSize.medium,
               rating: _minSafetyRating,
-              onRatingUpdate: (newRating) => innerSetState(
+              onRatingUpdate: (double newRating) => innerSetState(
                 () => _minSafetyRating = newRating.toInt(),
               ),
             ),
@@ -103,7 +103,7 @@ class SearchSuggestionFilter {
             CustomRatingBar(
               size: CustomRatingBarSize.medium,
               rating: _minReliabilityRating,
-              onRatingUpdate: (newRating) => innerSetState(
+              onRatingUpdate: (double newRating) => innerSetState(
                 () => _minReliabilityRating = newRating.toInt(),
               ),
             ),
@@ -111,7 +111,7 @@ class SearchSuggestionFilter {
             CustomRatingBar(
               size: CustomRatingBarSize.medium,
               rating: _minHospitalityRating,
-              onRatingUpdate: (newRating) => innerSetState(
+              onRatingUpdate: (double newRating) => innerSetState(
                 () => _minHospitalityRating = newRating.toInt(),
               ),
             ),
@@ -128,22 +128,22 @@ class SearchSuggestionFilter {
   Widget _buildFeaturesFilter(BuildContext context, void Function(void Function()) innerSetState) {
     List<Feature> shownFeatures;
     if (_isFeatureListExpanded) {
-      shownFeatures = {..._selectedFeatures, ...Feature.values}.toList();
+      shownFeatures = <Feature>{..._selectedFeatures, ...Feature.values}.toList();
     } else {
-      shownFeatures = {..._selectedFeatures, ..._retractedAdditionalFeatures}.toList();
+      shownFeatures = <Feature>{..._selectedFeatures, ..._retractedAdditionalFeatures}.toList();
     }
     return _filterCategory(
       context,
       S.of(context).searchSuggestionsFilterFeatures,
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+        children: <Widget>[
           Wrap(
             runSpacing: -10,
             spacing: 2,
-            children: List.generate(
+            children: List<FilterChip>.generate(
               shownFeatures.length,
-              (index) {
+              (int index) {
                 Feature feature = shownFeatures[index];
                 bool featureSelected = _selectedFeatures.contains(feature);
                 return FilterChip(
@@ -153,7 +153,7 @@ class SearchSuggestionFilter {
                   tooltip: featureSelected
                       ? S.of(context).searchSuggestionsFilterFeaturesDeselectTooltip
                       : S.of(context).searchSuggestionsFilterFeaturesSelectTooltip,
-                  onSelected: (selected) {
+                  onSelected: (bool selected) {
                     if (featureSelected) {
                       innerSetState(() {
                         _selectedFeatures.remove(feature);
@@ -161,7 +161,7 @@ class SearchSuggestionFilter {
                       });
                     } else {
                       Feature? mutuallyExclusiveFeature = _selectedFeatures
-                          .firstWhereOrNull((selectedFeature) => selectedFeature.isMutuallyExclusive(feature));
+                          .firstWhereOrNull((Feature selectedFeature) => selectedFeature.isMutuallyExclusive(feature));
                       if (mutuallyExclusiveFeature != null) {
                         String description = mutuallyExclusiveFeature.getDescription(context);
                         String text = S.of(context).pageProfileEditProfileFeaturesMutuallyExclusive(description);
@@ -182,9 +182,9 @@ class SearchSuggestionFilter {
             onPressed: () => innerSetState(() {
               _isFeatureListExpanded = !_isFeatureListExpanded;
               if (_selectedFeatures.isNotEmpty) {
-                _retractedAdditionalFeatures = [];
+                _retractedAdditionalFeatures = <Feature>[];
               } else {
-                _retractedAdditionalFeatures = [..._commonFeatures];
+                _retractedAdditionalFeatures = <Feature>[..._commonFeatures];
               }
             }),
             child: Text(_isFeatureListExpanded ? S.of(context).retract : S.of(context).expand),
@@ -199,14 +199,14 @@ class SearchSuggestionFilter {
       context,
       S.of(context).searchSuggestionsFilterDeviation,
       Row(
-        children: [
+        children: <Widget>[
           SizedBox(
             width: 60,
             height: 60,
             child: TextField(
               controller: _maxDeviationController,
               keyboardType: TextInputType.number,
-              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
             ),
           ),
           Text(S.of(context).searchSuggestionsFilterDeviationHours),
@@ -219,11 +219,11 @@ class SearchSuggestionFilter {
     return _filterCategory(
       context,
       S.of(context).searchSuggestionsFilterSorting,
-      DropdownButton(
+      DropdownButton<SearchSuggestionSorting>(
         value: _sorting,
         items: SearchSuggestionSorting.values
             .map(
-              (sorting) => DropdownMenuItem(
+              (SearchSuggestionSorting sorting) => DropdownMenuItem<SearchSuggestionSorting>(
                 value: sorting,
                 child: Text(sorting.getDescription(context)),
               ),
@@ -241,7 +241,7 @@ class SearchSuggestionFilter {
       context: context,
       builder: (BuildContext context) => ScaffoldMessenger(
         child: StatefulBuilder(
-          builder: (context, innerSetState) {
+          builder: (BuildContext context, Function(VoidCallback) innerSetState) {
             return Scaffold(
               backgroundColor: Colors.transparent,
               body: AlertDialog(
@@ -249,7 +249,7 @@ class SearchSuggestionFilter {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
-                    children: [
+                    children: <Widget>[
                       _buildRatingFilter(context, innerSetState),
                       _buildFeaturesFilter(context, innerSetState),
                       _buildDeviationFilter(
@@ -281,8 +281,8 @@ class SearchSuggestionFilter {
   }
 
   Widget _buildSmallRatingIndicator(int rating, {Icon? icon}) {
-    return Row(children: [
-      if (icon != null) ...[icon, const SizedBox(width: 3)],
+    return Row(children: <Widget>[
+      if (icon != null) ...<Widget>[icon, const SizedBox(width: 3)],
       Text(rating.toString()),
       const Icon(
         Icons.star,
@@ -300,9 +300,9 @@ class SearchSuggestionFilter {
     bool isFeaturesDefault = _selectedFeatures.equals(_defaultFeatures);
     bool isDeviationDefault = _maxDeviationController.text == _defaultDeviation;
 
-    List<Widget> widgets = [];
+    List<Widget> widgets = <Widget>[];
     if (!isRatingDefault) {
-      List<Widget> ratingWidgets = [];
+      List<Widget> ratingWidgets = <Widget>[];
       if (_minRating != _defaultRating) {
         ratingWidgets.add(_buildSmallRatingIndicator(_minRating));
         if (_minComfortRating != _defaultRating ||
@@ -364,17 +364,21 @@ class SearchSuggestionFilter {
       widgets.add(ratingsRow);
     }
     if (!isFeaturesDefault) {
-      Widget featuresRow = Row(children: _selectedFeatures.map((feature) => feature.getIcon(context)).toList());
+      Widget featuresRow = Row(children: _selectedFeatures.map((Feature feature) => feature.getIcon(context)).toList());
       widgets.add(featuresRow);
     }
     if (!isDeviationDefault) {
       Widget deviationWidget = Row(
-        children: [const Icon(Icons.schedule), const SizedBox(width: 6), Text("± ${_maxDeviationController.text}")],
+        children: <Widget>[
+          const Icon(Icons.schedule),
+          const SizedBox(width: 6),
+          Text("± ${_maxDeviationController.text}")
+        ],
       );
       widgets.add(deviationWidget);
     }
     Widget sortingWidget = Row(
-      children: [const Icon(Icons.sort), Text(_sorting.getDescription(context))],
+      children: <Widget>[const Icon(Icons.sort), Text(_sorting.getDescription(context))],
     );
     widgets.add(sortingWidget);
     int numDividers = widgets.length - 1;
@@ -390,7 +394,7 @@ class SearchSuggestionFilter {
           child: Padding(
             padding: const EdgeInsets.all(6),
             child: Row(
-              children: [
+              children: <Widget>[
                 const Icon(Icons.tune),
                 const SizedBox(width: 6),
                 Expanded(
@@ -424,7 +428,7 @@ class SearchSuggestionFilter {
                 (!driverReview.isSafetySet || driverReview.safetyRating >= _minSafetyRating) &&
                 (!driverReview.isReliabilitySet || driverReview.reliabilityRating >= _minReliabilityRating) &&
                 (!driverReview.isHospitalitySet || driverReview.hospitalityRating >= _minHospitalityRating);
-            bool featuresSatisfied = Set.of(driver.features!).containsAll(_selectedFeatures);
+            bool featuresSatisfied = Set<Feature>.of(driver.features!).containsAll(_selectedFeatures);
             bool maxDeviationSatisfied =
                 date.difference(ride.startTime) < Duration(hours: int.parse(_maxDeviationController.text));
             return ratingSatisfied && featuresSatisfied && maxDeviationSatisfied;
@@ -467,7 +471,7 @@ extension SearchSuggestionSortingExtension on SearchSuggestionSorting {
     int priceFunc(Ride ride1, Ride ride2) => ((ride1.price! - ride2.price!) * 100).toInt();
     switch (this) {
       case SearchSuggestionSorting.relevance:
-        return (ride1, ride2) =>
+        return (Ride ride1, Ride ride2) =>
             timeProximityFunc(ride1, ride2) + travelDurationFunc(ride1, ride2) + priceFunc(ride1, ride2);
       case SearchSuggestionSorting.timeProximity:
         return timeProximityFunc;

--- a/lib/util/buttons/button.dart
+++ b/lib/util/buttons/button.dart
@@ -20,7 +20,7 @@ class Button extends StatelessWidget {
     this.kind = ButtonKind.big,
   });
 
-  factory Button.error(text, {onPressed, Key? key}) {
+  factory Button.error(String text, {Function()? onPressed, Key? key}) {
     return Button(
       text,
       onPressed: onPressed,
@@ -29,7 +29,7 @@ class Button extends StatelessWidget {
     );
   }
 
-  factory Button.disabled(text, {Key? key}) {
+  factory Button.disabled(String text, {Key? key}) {
     return Button(
       text,
       onPressed: null,
@@ -38,7 +38,7 @@ class Button extends StatelessWidget {
     );
   }
 
-  factory Button.submit(text, {onPressed}) {
+  factory Button.submit(String text, {Function()? onPressed}) {
     return Button(
       text,
       onPressed: onPressed,

--- a/lib/util/buttons/custom_banner.dart
+++ b/lib/util/buttons/custom_banner.dart
@@ -8,9 +8,9 @@ class CustomBanner extends StatelessWidget {
 
   const CustomBanner(this.text, {super.key, this.displayColorKind = DisplayColorKind.primary});
 
-  factory CustomBanner.error(text, {Key? key}) =>
+  factory CustomBanner.error(String text, {Key? key}) =>
       CustomBanner(text, displayColorKind: DisplayColorKind.error, key: key);
-  factory CustomBanner.warning(text, {Key? key}) =>
+  factory CustomBanner.warning(String text, {Key? key}) =>
       CustomBanner(text, displayColorKind: DisplayColorKind.warning, key: key);
 
   @override

--- a/lib/util/buttons/loading_button.dart
+++ b/lib/util/buttons/loading_button.dart
@@ -23,7 +23,7 @@ class _LoadingButtonState extends State<LoadingButton> {
   @override
   Widget build(BuildContext context) {
     return ProgressButton.icon(
-      iconedButtons: {
+      iconedButtons: <ButtonState, IconedButton>{
         ButtonState.idle: IconedButton(
           text: widget.idleText ?? S.of(context).formSubmit,
           icon: widget.idleIcon ??

--- a/lib/util/fields/email_field.dart
+++ b/lib/util/fields/email_field.dart
@@ -12,7 +12,7 @@ extension EmailValidator on String {
 class EmailField extends StatelessWidget {
   final TextEditingController? controller;
 
-  const EmailField({key, this.controller}) : super(key: key);
+  const EmailField({super.key, this.controller});
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +24,7 @@ class EmailField extends StatelessWidget {
       ),
       keyboardType: TextInputType.emailAddress,
       controller: controller,
-      validator: (value) {
+      validator: (String? value) {
         if (value == null || value.isEmpty) {
           return S.of(context).formEmailValidateEmpty;
         } else if (!value.isValidEmail()) {

--- a/lib/util/fields/password_field.dart
+++ b/lib/util/fields/password_field.dart
@@ -8,15 +8,15 @@ class PasswordField extends StatelessWidget {
   final String? Function(String?)? validator;
   final TextEditingController? controller;
 
-  const PasswordField(
-      {key,
-      required this.labelText,
-      this.hintText = "",
-      this.errorText,
-      this.helperText,
-      this.controller,
-      this.validator})
-      : super(key: key);
+  const PasswordField({
+    super.key,
+    required this.labelText,
+    this.hintText = "",
+    this.errorText,
+    this.helperText,
+    this.controller,
+    this.validator,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/util/icon_widget.dart
+++ b/lib/util/icon_widget.dart
@@ -10,8 +10,8 @@ class IconWidget extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: count <= 2
-          ? List.generate(count, (index) => icon)
-          : [
+          ? List<Widget>.generate(count, (int index) => icon)
+          : <Widget>[
               icon,
               const SizedBox(width: 2),
               Text("x$count"),

--- a/lib/util/locale_manager.dart
+++ b/lib/util/locale_manager.dart
@@ -7,13 +7,13 @@ import 'storage_manager.dart';
 LocaleManager localeManager = LocaleManager();
 
 class LocaleManager with ChangeNotifier {
-  final supportedLocales = S.supportedLocales;
+  final List<Locale> supportedLocales = S.supportedLocales;
   late Locale currentLocale;
 
   Future<void> loadCurrentLocale() async {
-    await StorageManager.readData('locale').then((value) {
+    await StorageManager.readData('locale').then((dynamic value) {
       value ??= 'en';
-      currentLocale = supportedLocales.firstWhere((element) => element.languageCode == value);
+      currentLocale = supportedLocales.firstWhere((Locale element) => element.languageCode == value);
       notifyListeners();
     });
   }

--- a/lib/util/model.dart
+++ b/lib/util/model.dart
@@ -23,7 +23,7 @@ abstract class Model {
   Map<String, dynamic> toJsonForApi() {
     return toJson()
       ..addAll(
-        {
+        <String, dynamic>{
           'id': id,
           'created_at': createdAt?.toIso8601String(),
         },

--- a/lib/util/own_theme_fields.dart
+++ b/lib/util/own_theme_fields.dart
@@ -16,7 +16,7 @@ class OwnThemeFields {
 }
 
 extension ThemeDataExtensions on ThemeData {
-  static final Map<InputDecorationTheme, OwnThemeFields> _own = {};
+  static final Map<InputDecorationTheme, OwnThemeFields> _own = <InputDecorationTheme, OwnThemeFields>{};
 
   void addOwn(OwnThemeFields own) {
     _own[inputDecorationTheme] = own;
@@ -25,7 +25,7 @@ extension ThemeDataExtensions on ThemeData {
   static OwnThemeFields? empty;
 
   OwnThemeFields own() {
-    var o = _own[inputDecorationTheme];
+    OwnThemeFields? o = _own[inputDecorationTheme];
     if (o == null) {
       empty ??= const OwnThemeFields();
       o = empty;

--- a/lib/util/profiles/profile_chip.dart
+++ b/lib/util/profiles/profile_chip.dart
@@ -26,7 +26,7 @@ class ProfileChip extends StatelessWidget {
           labelPadding: const EdgeInsets.all(5),
           padding: const EdgeInsets.all(5),
           onPressed: () {
-            Navigator.of(context).push(MaterialPageRoute(builder: (_) => ProfilePage.fromProfile(profile)));
+            Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => ProfilePage.fromProfile(profile)));
           },
         ),
       ),

--- a/lib/util/profiles/profile_widget.dart
+++ b/lib/util/profiles/profile_widget.dart
@@ -34,7 +34,7 @@ class ProfileWidget extends StatelessWidget {
       button: isTappable,
       tooltip: S.of(context).seeProfile,
       child: Row(
-        children: [
+        children: <Widget>[
           Avatar(profile, size: size),
           const SizedBox(width: 5),
           Text(profile.username, style: TextStyle(fontSize: size)),
@@ -43,13 +43,16 @@ class ProfileWidget extends StatelessWidget {
     );
     if (actionWidget != null) {
       profileRow = Stack(
-        children: [profileRow, Positioned.fill(child: Align(alignment: Alignment.centerRight, child: actionWidget!))],
+        children: <Widget>[
+          profileRow,
+          Positioned.fill(child: Align(alignment: Alignment.centerRight, child: actionWidget!))
+        ],
       );
     }
     if (showDescription && (profile.description?.isNotEmpty ?? false)) {
       profileRow = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+        children: <Widget>[
           profileRow,
           const SizedBox(height: 10),
           Text(profile.description!),
@@ -61,8 +64,8 @@ class ProfileWidget extends StatelessWidget {
             onTap: () {
               onTap ??
                   Navigator.of(context)
-                      .push(MaterialPageRoute(builder: (_) => ProfilePage.fromProfile(profile)))
-                      .then((value) => onPop?.call(value));
+                      .push(MaterialPageRoute<dynamic>(builder: (_) => ProfilePage.fromProfile(profile)))
+                      .then((dynamic value) => onPop?.call(value));
             },
             child: profileRow,
           )

--- a/lib/util/profiles/profile_wrap_list.dart
+++ b/lib/util/profiles/profile_wrap_list.dart
@@ -11,7 +11,7 @@ class ProfileWrapList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
+    return Column(children: <Widget>[
       const SizedBox(height: 5),
       Align(
         alignment: Alignment.centerLeft,
@@ -24,9 +24,9 @@ class ProfileWrapList extends StatelessWidget {
           alignment: WrapAlignment.start,
           spacing: -5,
           runSpacing: -5,
-          children: List.generate(
+          children: List<Padding>.generate(
             profiles.length,
-            (index) => Padding(
+            (int index) => Padding(
               padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 5.0),
               child: ProfileChip(
                 profiles.elementAt(index),

--- a/lib/util/profiles/reviews/aggregate_review_widget.dart
+++ b/lib/util/profiles/reviews/aggregate_review_widget.dart
@@ -12,9 +12,9 @@ class AggregateReviewWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
-      children: [
+      children: <Widget>[
         Row(
-          children: [
+          children: <Widget>[
             ExcludeSemantics(
               child: Text(_aggregateReview.rating.toStringAsFixed(1), style: const TextStyle(fontSize: 20)),
             ),
@@ -36,10 +36,10 @@ class AggregateReviewWidget extends StatelessWidget {
             spacing: 5,
             runSpacing: 5,
             alignment: WrapAlignment.spaceBetween,
-            children: [
+            children: <Widget>[
               Row(
                 mainAxisSize: MainAxisSize.min,
-                children: [
+                children: <Widget>[
                   Text(S.of(context).reviewCategoryComfort),
                   const SizedBox(width: 10),
                   CustomRatingBarIndicator(rating: _aggregateReview.comfortRating),
@@ -47,7 +47,7 @@ class AggregateReviewWidget extends StatelessWidget {
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
-                children: [
+                children: <Widget>[
                   Text(S.of(context).reviewCategorySafety),
                   const SizedBox(width: 10),
                   CustomRatingBarIndicator(rating: _aggregateReview.safetyRating)
@@ -55,7 +55,7 @@ class AggregateReviewWidget extends StatelessWidget {
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
-                children: [
+                children: <Widget>[
                   Text(S.of(context).reviewCategoryReliability),
                   const SizedBox(width: 10),
                   CustomRatingBarIndicator(rating: _aggregateReview.reliabilityRating)
@@ -63,7 +63,7 @@ class AggregateReviewWidget extends StatelessWidget {
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
-                children: [
+                children: <Widget>[
                   Text(S.of(context).reviewCategoryHospitality),
                   const SizedBox(width: 10),
                   CustomRatingBarIndicator(rating: _aggregateReview.hospitalityRating)

--- a/lib/util/profiles/reviews/custom_rating_bar.dart
+++ b/lib/util/profiles/reviews/custom_rating_bar.dart
@@ -20,7 +20,7 @@ class CustomRatingBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return RatingBar.builder(
       minRating: 1,
-      itemBuilder: (context, _) => const Icon(
+      itemBuilder: (BuildContext context, _) => const Icon(
         Icons.star,
         color: Colors.amber,
       ),

--- a/lib/util/profiles/reviews/custom_rating_bar_indicator.dart
+++ b/lib/util/profiles/reviews/custom_rating_bar_indicator.dart
@@ -21,7 +21,7 @@ class CustomRatingBarIndicator extends StatelessWidget {
       label: S.of(context).ratingBarSemantics(rating.toStringAsFixed(1)),
       child: RatingBarIndicator(
         rating: rating,
-        itemBuilder: (context, index) => const Icon(
+        itemBuilder: (BuildContext context, int index) => const Icon(
           Icons.star,
           color: Colors.amber,
         ),

--- a/lib/util/search/address_search_delegate.dart
+++ b/lib/util/search/address_search_delegate.dart
@@ -8,7 +8,7 @@ import 'address_suggestion_manager.dart';
 class AddressSearchDelegate extends SearchDelegate<AddressSuggestion?> {
   @override
   List<Widget> buildActions(BuildContext context) {
-    return [
+    return <Widget>[
       IconButton(
         icon: const Icon(Icons.clear),
         onPressed: () {
@@ -52,10 +52,10 @@ class AddressSearchDelegate extends SearchDelegate<AddressSuggestion?> {
   @override
   Widget buildSuggestions(BuildContext context) {
     return StatefulBuilder(
-      builder: (BuildContext context, setState) {
+      builder: (BuildContext context, Function(VoidCallback) setState) {
         return FutureBuilder<List<AddressSuggestion>>(
           future: addressSuggestionManager.getSuggestions(query),
-          builder: (context, snapshot) {
+          builder: (BuildContext context, AsyncSnapshot<List<AddressSuggestion>> snapshot) {
             if (snapshot.hasData) {
               List<AddressSuggestion> suggestions = snapshot.data!;
               if (suggestions.isNotEmpty) {
@@ -63,8 +63,8 @@ class AddressSearchDelegate extends SearchDelegate<AddressSuggestion?> {
                   shrinkWrap: true,
                   itemCount: suggestions.length,
                   physics: const AlwaysScrollableScrollPhysics(),
-                  itemBuilder: (context, index) {
-                    var suggestion = suggestions[index];
+                  itemBuilder: (BuildContext context, int index) {
+                    AddressSuggestion suggestion = suggestions[index];
                     return ListTile(
                       leading: suggestion.getIcon(),
                       title: Text(suggestion.toString()),
@@ -82,7 +82,7 @@ class AddressSearchDelegate extends SearchDelegate<AddressSuggestion?> {
                       onTap: () => close(context, suggestion),
                     );
                   },
-                  separatorBuilder: (context, index) {
+                  separatorBuilder: (BuildContext context, int index) {
                     return const Divider();
                   },
                 );

--- a/lib/util/search/address_search_delegate.dart
+++ b/lib/util/search/address_search_delegate.dart
@@ -38,7 +38,7 @@ class AddressSearchDelegate extends SearchDelegate<AddressSuggestion?> {
   // [bool mounted = true] is a hack to be able to use context
   // (StatelessWidget is always mounted, so this is fine)
   void returnFirstResult(BuildContext context, [bool mounted = true]) async {
-    final List<AddressSuggestion> suggestions = await addressSuggestionManager.getAddressSuggestions(query);
+    final List<AddressSuggestion> suggestions = await addressSuggestionManager.getSuggestions(query);
 
     if (mounted) close(context, suggestions.firstOrNull);
   }

--- a/lib/util/search/address_search_field.dart
+++ b/lib/util/search/address_search_field.dart
@@ -53,7 +53,7 @@ class AddressSearchField extends StatelessWidget {
           hintText: getHintText(context),
         ),
         readOnly: true,
-        validator: (value) {
+        validator: (String? value) {
           if (value == null || value.isEmpty) {
             return getValidatorEmptyText(context);
           }

--- a/lib/util/search/address_suggestion.dart
+++ b/lib/util/search/address_suggestion.dart
@@ -32,9 +32,9 @@ class AddressSuggestion {
     Position pos = Position.fromDynamicValues(posJson['lat'], posJson['lng']);
 
     List<Map<String, dynamic>> regions = List<Map<String, dynamic>>.from(json['regions']);
-    String postalCode = _extractFromRegions(regions, [13]);
-    String city = _extractFromRegions(regions, [8, 7, 6, 5, 4]);
-    String country = _extractFromRegions(regions, [2]);
+    String postalCode = _extractFromRegions(regions, <int>[13]);
+    String city = _extractFromRegions(regions, <int>[8, 7, 6, 5, 4]);
+    String country = _extractFromRegions(regions, <int>[2]);
 
     return AddressSuggestion(
       name: name,
@@ -66,14 +66,14 @@ class AddressSuggestion {
   }
 
   static List<AddressSuggestion> deduplicate(List<AddressSuggestion> suggestions) {
-    var seen = <AddressSuggestion>{};
-    return suggestions.where((suggestion) => seen.add(suggestion)).toList();
+    Set<AddressSuggestion> seen = <AddressSuggestion>{};
+    return suggestions.where((AddressSuggestion suggestion) => seen.add(suggestion)).toList();
   }
 
   static String _extractFromRegions(List<Map<String, dynamic>> regions, List<int> adminLevels) {
     for (int adminLevel in adminLevels) {
       try {
-        return regions.firstWhere((region) => region['admin_level'] == adminLevel)['name'];
+        return regions.firstWhere((Map<String, dynamic> region) => region['admin_level'] == adminLevel)['name'];
       } catch (e) {
         continue;
       }
@@ -85,7 +85,7 @@ class AddressSuggestion {
     return AddressSuggestion(
       name: json['name'],
       position: Position.fromJson(json['position']),
-      type: AddressSuggestionType.values.firstWhere((e) => e.name == json['type']),
+      type: AddressSuggestionType.values.firstWhere((AddressSuggestionType e) => e.name == json['type']),
       postalCode: json['postal_code'],
       city: json['city'],
       country: json['country'],
@@ -95,7 +95,7 @@ class AddressSuggestion {
   }
 
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'name': name,
       'position': position.toJson(),
       'type': type.name,

--- a/lib/util/search/address_suggestion_manager.dart
+++ b/lib/util/search/address_suggestion_manager.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:deep_pick/deep_pick.dart';
 import 'package:fuzzywuzzy/fuzzywuzzy.dart';
 import 'package:fuzzywuzzy/model/extracted_result.dart';
 
@@ -126,9 +127,11 @@ class AddressSuggestionManager {
     String response = await request.close().then((HttpClientResponse value) => value.transform(utf8.decoder).join());
 
     Map<String, dynamic> responseMap = json.decode(response);
-    Map<String, dynamic> content = responseMap['content'];
 
-    return content['guesses'];
+    List<Map<String, dynamic>> guesses =
+        pick(responseMap, 'content', 'guesses').asListOrEmpty((RequiredPick p0) => p0.value as Map<String, dynamic>);
+
+    return guesses;
   }
 
   Future<List<AddressSuggestion>> getHistorySuggestions(String query) async {

--- a/lib/util/search/position.dart
+++ b/lib/util/search/position.dart
@@ -15,7 +15,7 @@ class Position {
   }
 
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'lat': lat,
       'lng': lng,
     };

--- a/lib/util/storage_manager.dart
+++ b/lib/util/storage_manager.dart
@@ -2,7 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class StorageManager {
   static void saveData(String key, dynamic value) async {
-    final prefs = await SharedPreferences.getInstance();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
     if (value is int) {
       prefs.setInt(key, value);
     } else if (value is String) {
@@ -17,18 +17,18 @@ class StorageManager {
   }
 
   static Future<List<String>> readStringList(String key) async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getStringList(key) ?? [];
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(key) ?? <String>[];
   }
 
   static Future<dynamic> readData(String key) async {
-    final prefs = await SharedPreferences.getInstance();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
     dynamic obj = prefs.get(key);
     return obj;
   }
 
   static Future<bool> deleteData(String key) async {
-    final prefs = await SharedPreferences.getInstance();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
     return prefs.remove(key);
   }
 }

--- a/lib/util/supabase.dart
+++ b/lib/util/supabase.dart
@@ -19,7 +19,7 @@ class SupabaseManager {
 
   static Future<void> reloadCurrentProfile() async {
     try {
-      final response = await supabaseClient
+      final Map<String, dynamic>? response = await supabaseClient
           .from('profiles')
           .select<Map<String, dynamic>?>()
           .eq('auth_id', supabaseClient.auth.currentUser!.id)

--- a/lib/util/theme_manager.dart
+++ b/lib/util/theme_manager.dart
@@ -18,7 +18,7 @@ class ThemeManager with ChangeNotifier {
   late ThemeMode currentThemeMode;
 
   Future<void> loadTheme() async {
-    await StorageManager.readData('themeMode').then((value) {
+    await StorageManager.readData('themeMode').then((dynamic value) {
       switch (value) {
         case 'system':
           currentThemeMode = ThemeMode.system;

--- a/lib/util/trip/drive_card.dart
+++ b/lib/util/trip/drive_card.dart
@@ -15,7 +15,7 @@ class DriveCard extends TripCard<Drive> {
   State<DriveCard> createState() => _DriveCardState();
 }
 
-class _DriveCardState extends TripCardState<DriveCard> {
+class _DriveCardState extends TripCardState<Drive, DriveCard> {
   late Drive _drive;
   bool _fullyLoaded = false;
 
@@ -59,11 +59,11 @@ class _DriveCardState extends TripCardState<DriveCard> {
   void Function() get onTap {
     return () => Navigator.of(context)
         .push(
-          MaterialPageRoute(
-            builder: (context) => DriveDetailPage.fromDrive(_drive),
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => DriveDetailPage.fromDrive(_drive),
           ),
         )
-        .then((value) => loadDrive());
+        .then((_) => loadDrive());
   }
 
   @override
@@ -80,9 +80,9 @@ class _DriveCardState extends TripCardState<DriveCard> {
     } else {
       if (_drive.cancelled) {
         return Theme.of(context).errorColor;
-      } else if (_drive.rides!.any((ride) => ride.status == RideStatus.pending)) {
+      } else if (_drive.rides!.any((Ride ride) => ride.status == RideStatus.pending)) {
         return Theme.of(context).own().warning;
-      } else if (_drive.rides!.any((ride) => ride.status == RideStatus.approved)) {
+      } else if (_drive.rides!.any((Ride ride) => ride.status == RideStatus.approved)) {
         return Theme.of(context).own().success;
       } else {
         return Theme.of(context).disabledColor;

--- a/lib/util/trip/pending_ride_card.dart
+++ b/lib/util/trip/pending_ride_card.dart
@@ -18,7 +18,7 @@ class PendingRideCard extends TripCard<Ride> {
   State<PendingRideCard> createState() => _PendingRideCardState();
 }
 
-class _PendingRideCardState extends TripCardState<PendingRideCard> {
+class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
   static const Duration extraTime = Duration(minutes: 5);
 
   late Ride _ride;
@@ -61,7 +61,7 @@ class _PendingRideCardState extends TripCardState<PendingRideCard> {
   @override
   Widget buildRightSide() {
     return ButtonBar(
-      children: [
+      children: <Widget>[
         IconButton(
           onPressed: (() => showApproveDialog(context)),
           icon: const Icon(Icons.check_circle_outline, color: Colors.green, size: 50.0),
@@ -87,7 +87,7 @@ class _PendingRideCardState extends TripCardState<PendingRideCard> {
   void approveRide() async {
     await SupabaseManager.supabaseClient.rpc(
       'approve_ride',
-      params: {'ride_id': _ride.id},
+      params: <String, dynamic>{'ride_id': _ride.id},
     );
     // todo: notify rider
     widget.reloadPage();
@@ -96,7 +96,7 @@ class _PendingRideCardState extends TripCardState<PendingRideCard> {
   void rejectRide() async {
     await SupabaseManager.supabaseClient.rpc(
       'reject_ride',
-      params: {'ride_id': _ride.id},
+      params: <String, dynamic>{'ride_id': _ride.id},
     );
     //todo: notify rider
     widget.reloadPage();
@@ -105,7 +105,7 @@ class _PendingRideCardState extends TripCardState<PendingRideCard> {
   void showApproveDialog(BuildContext context) {
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
+      builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).cardPendingRideApproveDialogTitle),
         content: Text(S.of(context).cardPendingRideApproveDialogMessage),
         actions: <Widget>[
@@ -145,7 +145,7 @@ class _PendingRideCardState extends TripCardState<PendingRideCard> {
   void showRejectDialog(BuildContext context) {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
+      builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).cardPendingRideRejectDialogTitle),
         content: Text(S.of(context).cardPendingRideRejectDialogMessage),
         actions: <Widget>[

--- a/lib/util/trip/ride_card.dart
+++ b/lib/util/trip/ride_card.dart
@@ -22,7 +22,7 @@ class RideCard extends TripCard<Ride> {
   State<RideCard> createState() => _RideCardState();
 }
 
-class _RideCardState extends TripCardState<RideCard> {
+class _RideCardState extends TripCardState<Ride, RideCard> {
   late Ride _ride;
   late Profile _driver;
   bool _fullyLoaded = false;
@@ -81,8 +81,8 @@ class _RideCardState extends TripCardState<RideCard> {
   @override
   void Function() get onTap {
     return () => Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => RideDetailPage.fromRide(_ride),
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => RideDetailPage.fromRide(_ride),
           ),
         );
   }

--- a/lib/util/trip/seat_indicator.dart
+++ b/lib/util/trip/seat_indicator.dart
@@ -16,9 +16,9 @@ class SeatIndicator extends StatelessWidget {
 
     if (trip is Drive) {
       int? maxUsedSeats = (trip as Drive).getMaxUsedSeats();
-      seatIcons = List.generate(
+      seatIcons = List<Icon>.generate(
         trip.seats,
-        (index) => Icon(
+        (int index) => Icon(
           Icons.chair,
           color: maxUsedSeats != null && index < maxUsedSeats
               ? Theme.of(context).colorScheme.primary
@@ -32,9 +32,9 @@ class SeatIndicator extends StatelessWidget {
             : S.of(context).labelUnknownSeats(trip.seats),
       );
     } else {
-      seatIcons = List.generate(
+      seatIcons = List<Icon>.generate(
         trip.seats,
-        (index) => Icon(
+        (int index) => Icon(
           Icons.chair,
           color: Theme.of(context).colorScheme.primary,
         ),
@@ -44,7 +44,7 @@ class SeatIndicator extends StatelessWidget {
 
     return MergeSemantics(
       child: Column(
-        children: [
+        children: <Widget>[
           Row(children: seatIcons),
           text,
         ],

--- a/lib/util/trip/trip.dart
+++ b/lib/util/trip/trip.dart
@@ -29,7 +29,7 @@ abstract class Trip extends Model {
 
   @override
   Map<String, dynamic> toJson() {
-    return {
+    return <String, dynamic>{
       'start': start,
       'start_lat': startPosition.lat,
       'start_lng': startPosition.lng,

--- a/lib/util/trip/trip_card.dart
+++ b/lib/util/trip/trip_card.dart
@@ -11,7 +11,7 @@ abstract class TripCard<T extends Trip> extends StatefulWidget {
   const TripCard(this.trip, {super.key});
 }
 
-abstract class TripCardState<T extends TripCard> extends State<T> {
+abstract class TripCardState<T extends Trip, U extends TripCard<T>> extends State<U> {
   late Trip trip;
 
   BorderRadius cardBorder = const BorderRadius.only(
@@ -27,7 +27,7 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
         borderRadius: BorderRadius.circular(10),
       ),
       child: Stack(
-        children: [
+        children: <Widget>[
           Container(
             foregroundDecoration: pickDecoration(),
             width: MediaQuery.of(context).size.width,
@@ -36,7 +36,7 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
               borderRadius: cardBorder,
             ),
             margin: const EdgeInsets.only(left: 10),
-            child: buildCardInfo(context),
+            child: buildCardInfo(),
           ),
           if (onTap != null)
             Positioned.fill(
@@ -60,16 +60,16 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
 
   EdgeInsets get middlePadding => const EdgeInsets.all(16);
 
-  FixedTimeline buildRoute(context) {
+  FixedTimeline buildRoute() {
     return FixedTimeline(
       theme: CustomTimelineTheme.of(context),
-      children: [
+      children: <Widget>[
         TimelineTile(
           contents: Padding(
             padding: const EdgeInsets.all(16.0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
+              children: <Widget>[
                 Text(
                   '${localeManager.formatTime(trip.startTime)}  ${trip.start}',
                   style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
@@ -87,10 +87,10 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
             padding: middlePadding,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
+              children: <Widget>[
                 SizedBox(
                   child: Row(
-                    children: [
+                    children: <Widget>[
                       const Icon(Icons.access_time_outlined),
                       const SizedBox(width: 4),
                       Text(
@@ -113,7 +113,7 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
             padding: const EdgeInsets.all(16),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
+              children: <Widget>[
                 Text(
                   '${localeManager.formatTime(trip.endTime)}  ${trip.end}',
                   style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
@@ -135,7 +135,7 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
+        children: <Widget>[
           buildTopLeft(),
           buildTopRight(),
         ],
@@ -146,19 +146,19 @@ abstract class TripCardState<T extends TripCard> extends State<T> {
   Widget buildBottom() {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
+      children: <Widget>[
         buildBottomLeft(),
         buildBottomRight(),
       ],
     );
   }
 
-  Widget buildCardInfo(context) {
+  Widget buildCardInfo() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
+      children: <Widget>[
         buildTop(),
-        Padding(padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16), child: buildRoute(context)),
+        Padding(padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16), child: buildRoute()),
         buildBottom(),
       ],
     );

--- a/lib/util/trip/trip_overview.dart
+++ b/lib/util/trip/trip_overview.dart
@@ -13,12 +13,12 @@ class TripOverview extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget startDest = Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
+      children: <Widget>[
         Expanded(
           child: MergeSemantics(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+              children: <Widget>[
                 Text(trip.start),
                 Text(
                   localeManager.formatTime(trip.startTime),
@@ -33,7 +33,7 @@ class TripOverview extends StatelessWidget {
           child: MergeSemantics(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
+              children: <Widget>[
                 Text(trip.end),
                 Text(
                   localeManager.formatTime(trip.endTime),
@@ -46,7 +46,7 @@ class TripOverview extends StatelessWidget {
       ],
     );
 
-    List<Widget> infoRowWidgets = [];
+    List<Widget> infoRowWidgets = <Widget>[];
 
     Widget dateWidget = Text(
       localeManager.formatDate(trip.startTime),
@@ -63,7 +63,7 @@ class TripOverview extends StatelessWidget {
     );
 
     Widget overview = Column(
-      children: [startDest, const SizedBox(height: 10.0), infoRow],
+      children: <Widget>[startDest, const SizedBox(height: 10.0), infoRow],
     );
 
     return overview;

--- a/lib/util/trip/trip_page_builder.dart
+++ b/lib/util/trip/trip_page_builder.dart
@@ -26,7 +26,7 @@ class TripPageBuilder {
           title: Text(title),
           bottom: TabBar(
             labelColor: Theme.of(context).colorScheme.onSurface,
-            tabs: [
+            tabs: <Tab>[
               Tab(text: S.of(context).widgetTripBuilderTabUpcoming),
               Tab(text: S.of(context).widgetTripBuilderTabPast),
             ],
@@ -35,12 +35,12 @@ class TripPageBuilder {
         body: Semantics(
           sortKey: const OrdinalSortKey(1),
           child: TabBarView(
-            children: [
+            children: <Widget>[
               TripStreamBuilder<T>(
                 stream: trips,
                 emptyMessage: S.of(context).widgetTripBuilderNoUpcoming(name),
-                filterTrips: (trips) => trips
-                    .where((trip) =>
+                filterTrips: (List<T> trips) => trips
+                    .where((T trip) =>
                         trip.endTime.isAfter(DateTime.now()) &&
                         (trip is! Ride || trip.status != RideStatus.withdrawnByRider) &&
                         !trip.hideInListView)
@@ -50,8 +50,8 @@ class TripPageBuilder {
               TripStreamBuilder<T>(
                 stream: trips,
                 emptyMessage: S.of(context).widgetTripBuilderNoPast(name),
-                filterTrips: (trips) => trips.reversed
-                    .where((trip) =>
+                filterTrips: (List<T> trips) => trips.reversed
+                    .where((T trip) =>
                         trip.endTime.isBefore(DateTime.now()) &&
                         (trip is! Ride || trip.status != RideStatus.withdrawnByRider) &&
                         !trip.hideInListView)

--- a/lib/util/trip/trip_stream_builder.dart
+++ b/lib/util/trip/trip_stream_builder.dart
@@ -13,7 +13,7 @@ class TripStreamBuilder<T extends Trip> extends StreamBuilder<List<T>> {
   }) : super(
           key: key,
           stream: stream,
-          builder: (context, snapshot) {
+          builder: (BuildContext context, AsyncSnapshot<List<T>> snapshot) {
             if (snapshot.hasData) {
               List<T> trips = snapshot.data!;
               List<T> filteredTrips = filterTrips(trips);
@@ -21,8 +21,8 @@ class TripStreamBuilder<T extends Trip> extends StreamBuilder<List<T>> {
                   ? Center(child: Text(emptyMessage))
                   : ListView.separated(
                       itemCount: filteredTrips.length,
-                      itemBuilder: (context, index) {
-                        final trip = filteredTrips[index];
+                      itemBuilder: (BuildContext context, int index) {
+                        T trip = filteredTrips[index];
 
                         return tripCard(trip);
                       },

--- a/lib/welcome/pages/forgot_password_page.dart
+++ b/lib/welcome/pages/forgot_password_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:progress_state_button/progress_button.dart';
 
@@ -67,11 +66,11 @@ class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
         redirectTo: kIsWeb ? null : 'io.supabase.flutter://reset-callback/',
       );
 
-      await Future.delayed(const Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(seconds: 1));
       setState(() {
         _state = ButtonState.success;
       });
-      await Future.delayed(const Duration(seconds: 2));
+      await Future<void>.delayed(const Duration(seconds: 2));
 
       if (mounted) {
         Navigator.of(context).pop();
@@ -85,7 +84,7 @@ class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
     setState(() {
       _state = ButtonState.fail;
     });
-    await Future.delayed(const Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     setState(() {
       _state = ButtonState.idle;
     });

--- a/lib/welcome/pages/login_page.dart
+++ b/lib/welcome/pages/login_page.dart
@@ -2,7 +2,6 @@ import 'dart:core';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:progress_state_button/progress_button.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -31,7 +30,7 @@ class _LoginPageState extends State<LoginPage> {
       body: const Center(
         child: CustomScrollView(
           physics: ClampingScrollPhysics(),
-          slivers: [
+          slivers: <Widget>[
             SliverFillRemaining(
               hasScrollBody: false,
               child: Padding(
@@ -55,8 +54,8 @@ class LoginForm extends StatefulWidget {
 
 class _LoginFormState extends State<LoginForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final emailController = TextEditingController();
-  final passwordController = TextEditingController();
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
   ButtonState _state = ButtonState.idle;
 
   void onSubmit() async {
@@ -96,7 +95,7 @@ class _LoginFormState extends State<LoginForm> {
     setState(() {
       _state = ButtonState.fail;
     });
-    await Future.delayed(const Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     setState(() {
       _state = ButtonState.idle;
     });
@@ -125,7 +124,7 @@ class _LoginFormState extends State<LoginForm> {
               labelText: S.of(context).formPassword,
               hintText: S.of(context).formPasswordHint,
               controller: passwordController,
-              validator: (value) {
+              validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return S.of(context).formPasswordValidateEmpty;
                 }
@@ -135,10 +134,8 @@ class _LoginFormState extends State<LoginForm> {
             TextButton(
               onPressed: () {
                 Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => ForgotPasswordPage(
-                      initialEmail: emailController.text,
-                    ),
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) => ForgotPasswordPage(initialEmail: emailController.text),
                   ),
                 );
               },
@@ -155,8 +152,8 @@ class _LoginFormState extends State<LoginForm> {
                 child: TextButton(
                   onPressed: () {
                     Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => const RegisterPage(),
+                      MaterialPageRoute<void>(
+                        builder: (BuildContext context) => const RegisterPage(),
                       ),
                     );
                   },

--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -43,10 +43,10 @@ class RegisterForm extends StatefulWidget {
 
 class _RegisterFormState extends State<RegisterForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final emailController = TextEditingController();
-  final usernameController = TextEditingController();
-  final passwordController = TextEditingController();
-  final passwordConfirmationController = TextEditingController();
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController usernameController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  final TextEditingController passwordConfirmationController = TextEditingController();
   ButtonState _state = ButtonState.idle;
 
   void onSubmit() async {
@@ -70,7 +70,7 @@ class _RegisterFormState extends State<RegisterForm> {
 
       if (user != null) {
         try {
-          await SupabaseManager.supabaseClient.from('profiles').insert({
+          await SupabaseManager.supabaseClient.from('profiles').insert(<String, dynamic>{
             'auth_id': user.id,
             'email': user.email,
             'username': usernameController.text,
@@ -82,7 +82,7 @@ class _RegisterFormState extends State<RegisterForm> {
           if (mounted) showSnackBar(S.of(context).failureSnackBar);
           return;
         }
-        await Future.delayed(const Duration(seconds: 2));
+        await Future<void>.delayed(const Duration(seconds: 2));
         setState(() {
           _state = ButtonState.success;
         });
@@ -109,7 +109,7 @@ class _RegisterFormState extends State<RegisterForm> {
     setState(() {
       _state = ButtonState.fail;
     });
-    await Future.delayed(const Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     setState(() {
       _state = ButtonState.idle;
     });
@@ -141,7 +141,7 @@ class _RegisterFormState extends State<RegisterForm> {
                 hintText: S.of(context).pageRegisterUsernameHint,
               ),
               controller: usernameController,
-              validator: (value) {
+              validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return S.of(context).pageRegisterUsernameValidateEmpty;
                 }
@@ -153,7 +153,7 @@ class _RegisterFormState extends State<RegisterForm> {
               labelText: S.of(context).formPassword,
               hintText: S.of(context).formPasswordHint,
               controller: passwordController,
-              validator: (value) {
+              validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return S.of(context).formPasswordValidateEmpty;
                 } else if (value.length < 8) {
@@ -175,7 +175,7 @@ class _RegisterFormState extends State<RegisterForm> {
               labelText: S.of(context).formPasswordConfirm,
               hintText: S.of(context).formPasswordConfirmHint,
               controller: passwordConfirmationController,
-              validator: (value) {
+              validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return S.of(context).formPasswordConfirmValidateEmpty;
                 } else if (value != passwordController.text) {

--- a/lib/welcome/pages/reset_password_page.dart
+++ b/lib/welcome/pages/reset_password_page.dart
@@ -42,8 +42,8 @@ class ResetPasswordForm extends StatefulWidget {
 
 class _ResetPasswordFormState extends State<ResetPasswordForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final passwordController = TextEditingController();
-  final passwordConfirmationController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  final TextEditingController passwordConfirmationController = TextEditingController();
   ButtonState _state = ButtonState.idle;
 
   void onSubmit() async {
@@ -64,7 +64,7 @@ class _ResetPasswordFormState extends State<ResetPasswordForm> {
     setState(() {
       _state = ButtonState.fail;
     });
-    await Future.delayed(const Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     setState(() {
       _state = ButtonState.idle;
     });
@@ -89,7 +89,7 @@ class _ResetPasswordFormState extends State<ResetPasswordForm> {
               labelText: S.of(context).formPassword,
               hintText: S.of(context).pageResetPasswordHint,
               controller: passwordController,
-              validator: (value) {
+              validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return S.of(context).pageResetPasswordValidateEmpty;
                 } else if (value.length < 8) {
@@ -111,7 +111,7 @@ class _ResetPasswordFormState extends State<ResetPasswordForm> {
               labelText: S.of(context).formPasswordConfirm,
               hintText: S.of(context).pageResetPasswordConfirmHint,
               controller: passwordConfirmationController,
-              validator: (value) {
+              validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return S.of(context).pageResetPasswordConfirmValidateEmpty;
                 } else if (value != passwordController.text) {

--- a/lib/welcome/pages/welcome_page.dart
+++ b/lib/welcome/pages/welcome_page.dart
@@ -16,12 +16,12 @@ class WelcomePage extends StatefulWidget {
 class _WelcomePageState extends State<WelcomePage> {
   static const double indicatorSize = 10;
   static const double indicatorMargin = 3;
-  static const List<String> images = ['assets/welcome1.png', 'assets/welcome2.png', 'assets/welcome3.png'];
+  static const List<String> images = <String>['assets/welcome1.png', 'assets/welcome2.png', 'assets/welcome3.png'];
 
   int activePage = 0;
 
-  List<Widget> indicators(imagesLength, currentIndex) {
-    return List<Widget>.generate(imagesLength, (index) {
+  List<Widget> indicators(int imagesLength, int currentIndex) {
+    return List<Container>.generate(imagesLength, (int index) {
       return Container(
         margin: const EdgeInsets.all(indicatorMargin),
         width: indicatorSize,
@@ -38,19 +38,19 @@ class _WelcomePageState extends State<WelcomePage> {
   Widget build(BuildContext context) {
     double height = MediaQuery.of(context).size.height;
     Widget carousel = Column(
-      children: [
+      children: <Widget>[
         SizedBox(
           height: height / 2 - indicatorSize - indicatorMargin * 2,
           child: PageView.builder(
             itemCount: images.length,
             pageSnapping: true,
             padEnds: false,
-            onPageChanged: (page) {
+            onPageChanged: (int page) {
               setState(() {
                 activePage = page;
               });
             },
-            itemBuilder: (context, pagePosition) {
+            itemBuilder: (BuildContext context, int pagePosition) {
               return Container(
                 margin: const EdgeInsets.all(10),
                 child: Image.asset(images[pagePosition]),
@@ -67,14 +67,14 @@ class _WelcomePageState extends State<WelcomePage> {
     Widget buttons = Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: [
+        children: <Widget>[
           Hero(
             tag: "LoginButton",
             transitionOnUserGestures: true,
             child: Button(
               S.of(context).pageWelcomeLogin,
               onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(builder: (context) => const LoginPage()),
+                MaterialPageRoute<void>(builder: (BuildContext context) => const LoginPage()),
               ),
             ),
           ),
@@ -85,7 +85,7 @@ class _WelcomePageState extends State<WelcomePage> {
             child: Button(
               S.of(context).pageWelcomeRegister,
               onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(builder: (context) => const RegisterPage()),
+                MaterialPageRoute<void>(builder: (BuildContext context) => const RegisterPage()),
               ),
             ),
           ),
@@ -96,10 +96,8 @@ class _WelcomePageState extends State<WelcomePage> {
             child: Button(
               S.of(context).pageWelcomeAnonymousSearch,
               onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const SearchRidePage(
-                    anonymous: true,
-                  ),
+                MaterialPageRoute<void>(
+                  builder: (BuildContext context) => const SearchRidePage(anonymous: true),
                 ),
               ),
             ),
@@ -111,7 +109,7 @@ class _WelcomePageState extends State<WelcomePage> {
       body: SafeArea(
         child: CustomScrollView(
           physics: const ClampingScrollPhysics(),
-          slivers: [
+          slivers: <Widget>[
             SliverFillRemaining(
               hasScrollBody: false,
               child: Padding(
@@ -121,7 +119,7 @@ class _WelcomePageState extends State<WelcomePage> {
                 ),
                 child: height > 378
                     ? Column(
-                        children: [
+                        children: <Widget>[
                           SizedBox(height: height / 2, child: carousel),
                           Expanded(child: buttons),
                         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -204,6 +204,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.4"
+  deep_pick:
+    dependency: "direct main"
+    description:
+      name: deep_pick
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   package_info_plus: ^3.0.2
   image_picker: ^0.8.6
   faker: ^2.1.0
+  deep_pick: ^0.10.0
 
 dev_dependencies:
   flutter_test:

--- a/test/analysis_options.yaml
+++ b/test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    always_specify_types: false

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -65,8 +65,6 @@ void main() {
           'hide_in_list_view': false,
         }
       ]));
-      final data = await Drive.getDrivesOfUser(1);
-      expect(data.first.driverId, 1);
     });
   });
 }


### PR DESCRIPTION
This is a big one. `always_specify_types` make sure that we will always declare types for every variable we encounter. You can look at the PR to see some common cases where this makes a difference:

- specifying `<String,dynamic>` for the json (for example when we talk to supabase)
- specifying `<Widget>` for Widget-Lists, for example in rows and columns
- generally all calls for `List.generate` and `[]` should signify the type of lists
- specifying the return type of `MaterialPageRoute` (mostly void, except if you need the response)
- `Future.delayed` becomes `Future<void>.delayed`

While doing this, I found some problems:
- some `fromJsonList` methods had weird parameters
- we used a dynamic `context` in our Edit...Pages. Now that flutter knows that it is a `BuildContext`, it showed the age-old problem with `context` across async gaps. So I had to change those pages to `Stateful` to get access to `mounted` (but I did see that flutter will have an easier `context.mounted`in the future: https://github.com/flutter/flutter/issues/111488. The annoying thing is that it's already in the docs, but not released yet: https://api.flutter.dev/flutter/widgets/BuildContext/mounted.html)

I disabled the lint rule in our tests, because I think it's more annoying than helpful in those files.