### PR TITLE
Fix address suggestions scoped by account

### DIFF
--- a/lib/util/search/address_suggestion_manager.dart
+++ b/lib/util/search/address_suggestion_manager.dart
@@ -17,8 +17,7 @@ class AddressSuggestionManager {
   static const String _storageKey = 'suggestions';
   static const int _maxSuggestionsStored = 100;
 
-  static late List<AddressSuggestion> _historySuggestions;
-  static bool _historySuggestionsLoaded = false;
+  static List<AddressSuggestion> _historySuggestions = [];
 
   // If the search is shorter than this, the server will return an empty list anyways.
   static const int searchLengthRequirement = 3;
@@ -50,16 +49,6 @@ class AddressSuggestionManager {
     Iterable<Map<String, dynamic>> suggestions = data.map((suggestion) => jsonDecode(suggestion));
     _historySuggestions =
         suggestions.map((suggestion) => AddressSuggestion.fromJson(suggestion, fromHistory: true)).toList();
-
-    _historySuggestionsLoaded = true;
-  }
-
-  void reloadHistorySuggestions() {
-    if (_historySuggestionsLoaded) {
-      _historySuggestions.clear();
-    }
-
-    loadHistorySuggestions();
   }
 
   Future<void> storeSuggestion(AddressSuggestion suggestion) async {

--- a/lib/util/search/address_suggestion_manager.dart
+++ b/lib/util/search/address_suggestion_manager.dart
@@ -18,6 +18,7 @@ class AddressSuggestionManager {
   static const int _maxSuggestionsStored = 100;
 
   static late List<AddressSuggestion> _historySuggestions;
+  static bool _historySuggestionsLoaded = false;
 
   // If the search is shorter than this, the server will return an empty list anyways.
   static const int searchLengthRequirement = 3;
@@ -49,6 +50,16 @@ class AddressSuggestionManager {
     Iterable<Map<String, dynamic>> suggestions = data.map((suggestion) => jsonDecode(suggestion));
     _historySuggestions =
         suggestions.map((suggestion) => AddressSuggestion.fromJson(suggestion, fromHistory: true)).toList();
+
+    _historySuggestionsLoaded = true;
+  }
+
+  void reloadHistorySuggestions() {
+    if (_historySuggestionsLoaded) {
+      _historySuggestions.clear();
+    }
+
+    loadHistorySuggestions();
   }
 
   Future<void> storeSuggestion(AddressSuggestion suggestion) async {

--- a/lib/util/supabase.dart
+++ b/lib/util/supabase.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../account/models/profile.dart';
+import 'search/address_suggestion_manager.dart';
 
 class SupabaseManager {
   static Profile? _currentProfile;
@@ -33,5 +34,8 @@ class SupabaseManager {
     } catch (e) {
       setCurrentProfile(null);
     }
+
+    // Reload the history suggestions to show the new profile's history.
+    addressSuggestionManager.reloadHistorySuggestions();
   }
 }

--- a/lib/util/supabase.dart
+++ b/lib/util/supabase.dart
@@ -36,6 +36,6 @@ class SupabaseManager {
     }
 
     // Reload the history suggestions to show the new profile's history.
-    addressSuggestionManager.reloadHistorySuggestions();
+    addressSuggestionManager.loadHistorySuggestions();
   }
 }


### PR DESCRIPTION
The suggestions were already scoped in local storage, but they were still present in memory after logout/login. Just reloading them from the correctly scoped storage does the trick.