### PR TITLE
Set to system locale on first start

### DIFF
--- a/lib/util/locale_manager.dart
+++ b/lib/util/locale_manager.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
@@ -19,7 +18,7 @@ class LocaleManager with ChangeNotifier {
       value ??= Platform.localeName.split('_').first;
 
       Locale locale =
-          supportedLocales.firstWhereOrNull((Locale element) => element.languageCode == value) ?? defaultLocale;
+          supportedLocales.firstWhere((Locale element) => element.languageCode == value, orElse: () => defaultLocale);
 
       setCurrentLocale(locale);
     });

--- a/lib/util/locale_manager.dart
+++ b/lib/util/locale_manager.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
@@ -7,14 +10,18 @@ import 'storage_manager.dart';
 LocaleManager localeManager = LocaleManager();
 
 class LocaleManager with ChangeNotifier {
+  static const Locale defaultLocale = Locale('en');
   final List<Locale> supportedLocales = S.supportedLocales;
   late Locale currentLocale;
 
   Future<void> loadCurrentLocale() async {
     await StorageManager.readData('locale').then((dynamic value) {
-      value ??= 'en';
-      currentLocale = supportedLocales.firstWhere((Locale element) => element.languageCode == value);
-      notifyListeners();
+      value ??= Platform.localeName.split('_').first;
+
+      Locale locale =
+          supportedLocales.firstWhereOrNull((Locale element) => element.languageCode == value) ?? defaultLocale;
+
+      setCurrentLocale(locale);
     });
   }
 


### PR DESCRIPTION
Fixes the app language on first startup. It should be read be from the system language. We will ignore any further change in the system language (should we do that?). 