### PR TITLE
Add support for coverage for windows

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,4 +1,8 @@
 ./scripts/coverage_helper.sh
 flutter test --coverage
 genhtml coverage/lcov.info -o coverage/html
-open coverage/html/index.html
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    open coverage/html/index.html
+else
+    start coverage/html/index.html
+fi


### PR DESCRIPTION
@Showcas Workflow to install lcov for Windows is described here: https://fredgrott.medium.com/lcov-on-windows-7c58dda07080
After that, it should work. I had to make this change because the open command is called start on Windows.