### PR TITLE
Fix factories

### DIFF
--- a/test/util/factories/drive_factory.dart
+++ b/test/util/factories/drive_factory.dart
@@ -57,7 +57,7 @@ class DriveFactory extends TripFactory<Drive> {
       seats: seats ?? random.nextInt(5) + 1,
       cancelled: cancelled ?? false,
       hideInListView: hideInListView ?? false,
-      driverId: generatedDriver?.id ?? randomId,
+      driverId: generatedDriver?.id ?? driverId ?? randomId,
       driver: generatedDriver,
       rides: generatedRides,
     );

--- a/test/util/factories/message_factory.dart
+++ b/test/util/factories/message_factory.dart
@@ -37,7 +37,7 @@ class MessageFactory extends ModelFactory<Message> {
       chatId: generatedChat?.id ?? randomId,
       chat: generatedChat,
       content: content ?? faker.lorem.sentences(random.nextInt(2) + 1).join(' '),
-      senderId: generatedSender?.id ?? randomId,
+      senderId: generatedSender?.id ?? senderId ?? randomId,
       sender: generatedSender,
       read: read ?? Random().nextBool(),
     );

--- a/test/util/factories/profile_feature_factory.dart
+++ b/test/util/factories/profile_feature_factory.dart
@@ -18,7 +18,7 @@ class ProfileFeatureFactory extends ModelFactory<ProfileFeature> {
     assert(profileId == null || profile?.value == null || profile!.value?.id == profileId);
 
     final Profile? generatedProfile =
-        profile == null ? ProfileFactory().generateFake(id: profileId, createDependencies: false) : profile.value;
+        getNullableParameterOr(profile, ProfileFactory().generateFake(id: profileId, createDependencies: false));
 
     return ProfileFeature(
       id: id ?? randomId,

--- a/test/util/factories/profile_feature_factory.dart
+++ b/test/util/factories/profile_feature_factory.dart
@@ -25,7 +25,7 @@ class ProfileFeatureFactory extends ModelFactory<ProfileFeature> {
       createdAt: createdAt ?? DateTime.now(),
       feature: feature ?? Feature.values[random.nextInt(Feature.values.length)],
       rank: rank ?? random.nextInt(5),
-      profileId: generatedProfile?.id ?? randomId,
+      profileId: generatedProfile?.id ?? profileId ?? randomId,
       profile: generatedProfile,
     );
   }

--- a/test/util/factories/report_factory.dart
+++ b/test/util/factories/report_factory.dart
@@ -21,9 +21,9 @@ class ReportFactory extends ModelFactory<Report> {
     assert(offenderId == null || offender?.value == null || offender!.value?.id == offenderId);
 
     final Profile? generatedReporter =
-        reporter == null ? ProfileFactory().generateFake(id: reporterId, createDependencies: false) : reporter.value;
+        getNullableParameterOr(reporter, ProfileFactory().generateFake(id: reporterId, createDependencies: false));
     final Profile? generatedOffender =
-        offender == null ? ProfileFactory().generateFake(id: offenderId, createDependencies: false) : offender.value;
+        getNullableParameterOr(offender, ProfileFactory().generateFake(id: offenderId, createDependencies: false));
 
     return Report(
       id: id ?? randomId,

--- a/test/util/factories/report_factory.dart
+++ b/test/util/factories/report_factory.dart
@@ -30,10 +30,10 @@ class ReportFactory extends ModelFactory<Report> {
       createdAt: createdAt ?? DateTime.now(),
       category: category ?? ReportCategory.values[random.nextInt(ReportCategory.values.length)],
       text: getNullableParameterOr(text, faker.lorem.sentences(random.nextInt(2) + 1).join(' ')),
-      offenderId: generatedReporter?.id ?? randomId,
-      offender: generatedReporter,
-      reporterId: generatedOffender?.id ?? randomId,
-      reporter: generatedOffender,
+      offenderId: generatedOffender?.id ?? offenderId ?? randomId,
+      offender: generatedOffender,
+      reporterId: generatedReporter?.id ?? reporterId ?? randomId,
+      reporter: generatedReporter,
     );
   }
 }

--- a/test/util/factories/review_factory.dart
+++ b/test/util/factories/review_factory.dart
@@ -38,9 +38,9 @@ class ReviewFactory extends ModelFactory<Review> {
       reliabilityRating: getNullableParameterOr(reliabilityRating, random.nextInt(Review.maxRating)),
       hospitalityRating: getNullableParameterOr(hospitalityRating, random.nextInt(Review.maxRating)),
       text: getNullableParameterOr(text, faker.lorem.sentences(random.nextInt(2) + 1).join(' ')),
-      writerId: generatedWriter?.id ?? randomId,
+      writerId: generatedWriter?.id ?? writerId ?? randomId,
       writer: generatedWriter,
-      receiverId: generatedReceiver?.id ?? randomId,
+      receiverId: generatedReceiver?.id ?? receiverId ?? randomId,
       receiver: generatedReceiver,
     );
   }

--- a/test/util/factories/ride_factory.dart
+++ b/test/util/factories/ride_factory.dart
@@ -28,19 +28,19 @@ class RideFactory extends TripFactory<Ride> {
     int? driveId,
     NullableParameter<Drive>? drive,
     int? riderId,
-    NullableParameter<Profile>? ride,
+    NullableParameter<Profile>? rider,
     int? chatId,
     NullableParameter<Chat>? chat,
     bool createDependencies = true,
   }) {
     assert(driveId == null || drive?.value == null || drive!.value?.id == driveId);
-    assert(riderId == null || ride?.value == null || ride!.value?.id == riderId);
+    assert(riderId == null || rider?.value == null || rider!.value?.id == riderId);
     assert(chatId == null || chat?.value == null || chat!.value?.id == chatId);
 
     final Drive? generatedDrive =
         getNullableParameterOr(drive, DriveFactory().generateFake(id: driveId, createDependencies: false));
     final Profile? generatedRider =
-        getNullableParameterOr(ride, ProfileFactory().generateFake(id: riderId, createDependencies: false));
+        getNullableParameterOr(rider, ProfileFactory().generateFake(id: riderId, createDependencies: false));
     final Chat? generatedChat =
         getNullableParameterOr(chat, ChatFactory().generateFake(id: chatId, createDependencies: false));
 

--- a/test/util/factories/ride_factory.dart
+++ b/test/util/factories/ride_factory.dart
@@ -59,11 +59,11 @@ class RideFactory extends TripFactory<Ride> {
       price: getNullableParameterOr(price, double.parse((random.nextDouble() * 10).toStringAsFixed(2))),
       status: status ?? RideStatus.values[random.nextInt(RideStatus.values.length)],
       hideInListView: hideInListView ?? false,
-      driveId: generatedDrive?.id ?? randomId,
+      driveId: generatedDrive?.id ?? driveId ?? randomId,
       drive: generatedDrive,
-      riderId: generatedRider?.id ?? randomId,
+      riderId: generatedRider?.id ?? riderId ?? randomId,
       rider: generatedRider,
-      chatId: generatedChat?.id ?? randomId,
+      chatId: generatedChat?.id ?? chatId ?? randomId,
       chat: generatedChat,
     );
   }


### PR DESCRIPTION
@istzen and I noticed that the factory foreign key logic was not perfect yet. The following usecase would not work:

Setting the related object to null via NullableParameter, but still wanting to set an id. For example:
```
drive: NullableParameter(null),
driveId: 1
```