### PR TITLE
Fix editing profile features

### DIFF
--- a/lib/account/pages/edit_account/edit_profile_features_page.dart
+++ b/lib/account/pages/edit_account/edit_profile_features_page.dart
@@ -22,6 +22,8 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
   late List<Feature> _features;
   late List<Feature> _otherFeatures;
 
+  bool _isSaving = false;
+
   @override
   void initState() {
     super.initState();
@@ -125,7 +127,7 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
             const SizedBox(height: 10),
             Button(
               S.of(context).save,
-              onPressed: onPressed,
+              onPressed: _isSaving ? null : onPressed,
             ),
           ],
         ),
@@ -208,6 +210,8 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
   }
 
   Future<void> onPressed() async {
+    setState(() => _isSaving = true);
+
     final List<Feature> previousFeatures = _profileFeatures.map((ProfileFeature e) => e.feature).toList();
 
     for (int index = 0; index < _features.length; index++) {
@@ -235,6 +239,8 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
           .eq('profile_id', widget.profile.id)
           .eq('feature', feature.index);
     }
+
+    setState(() => _isSaving = false);
 
     if (mounted) Navigator.of(context).pop();
   }


### PR DESCRIPTION
When you clicked on the button twice, then the features would be saved twice (and it would pop twice, which was even weirder). So the button needs to be disabled after the first click.

(@istzen are you happy with such a small PR? :D)