### PR TITLE
Unify snackbars

### DIFF
--- a/lib/account/pages/edit_account/edit_profile_features_page.dart
+++ b/lib/account/pages/edit_account/edit_profile_features_page.dart
@@ -1,9 +1,9 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
+import '../../../util/snackbar.dart';
 import '../../../util/supabase.dart';
 import '../../models/profile.dart';
 import '../../models/profile_feature.dart';
@@ -191,12 +191,12 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
           _features.firstWhereOrNull((Feature feature) => feature.isMutuallyExclusive(newFeature));
       if (mutuallyExclusiveFeature != null) {
         final String description = mutuallyExclusiveFeature.getDescription(context);
-        final String text = S.of(context).pageProfileEditProfileFeaturesMutuallyExclusive(description);
-        SemanticsService.announce(text, TextDirection.ltr);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(text)),
+        return showSnackBar(
+          context,
+          S.of(context).pageProfileEditProfileFeaturesMutuallyExclusive(description),
+          durationType: SnackBarDurationType.medium,
+          replace: true,
         );
-        return;
       }
 
       _otherFeatures.removeAt(indexInOtherFeatures);

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../util/buttons/button.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import '../models/profile.dart';
 import '../models/report.dart';
@@ -286,9 +287,7 @@ class _ProfilePageState extends State<ProfilePage> {
                     .then((bool? reportSent) {
                   if (reportSent ?? false) {
                     loadProfile();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(S.of(context).pageProfileButtonMessage)),
-                    );
+                    showSnackBar(context, S.of(context).pageProfileButtonMessage);
                   }
                 });
               },
@@ -402,8 +401,9 @@ class _ProfilePageState extends State<ProfilePage> {
       await loadProfile();
     } catch (error) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(S.of(context).widgetAvatarImageCouldNotBeStored)),
+        showSnackBar(
+          context,
+          S.of(context).widgetAvatarImageCouldNotBeStored,
         );
       }
     }

--- a/lib/account/pages/write_review_page.dart
+++ b/lib/account/pages/write_review_page.dart
@@ -6,6 +6,7 @@ import '../../util/buttons/loading_button.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/reviews/custom_rating_bar.dart';
 import '../../util/profiles/reviews/custom_rating_bar_size.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import '../models/profile.dart';
 import '../models/review.dart';
@@ -187,14 +188,11 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
       setState(() {
         _state = ButtonState.fail;
       });
-      const Duration duration = Duration(seconds: 1);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(S.of(context).pageWriteReviewRatingRequired),
-          duration: duration,
-        ),
-      );
-      await Future<void>.delayed(duration);
+
+      const SnackBarDurationType durationType = SnackBarDurationType.short;
+      showSnackBar(context, S.of(context).pageWriteReviewRatingRequired, durationType: durationType);
+      await Future<void>.delayed(durationType.duration);
+
       setState(() {
         _state = ButtonState.idle;
       });

--- a/lib/drives/pages/create_drive_page.dart
+++ b/lib/drives/pages/create_drive_page.dart
@@ -9,6 +9,7 @@ import '../../util/fields/increment_field.dart';
 import '../../util/locale_manager.dart';
 import '../../util/search/address_suggestion.dart';
 import '../../util/search/start_destination_timeline.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import '../../util/trip/trip.dart';
 import '../models/drive.dart';
@@ -126,19 +127,19 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
         final bool hasDrive =
             await Drive.userHasDriveAtTimeRange(DateTimeRange(start: _selectedDate, end: endTime), driver.id!);
         if (hasDrive && mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(S.of(context).pageCreateDriveYouAlreadyHaveDrive)),
+          return showSnackBar(
+            context,
+            S.of(context).pageCreateDriveYouAlreadyHaveDrive,
           );
-          return;
         }
 
         final bool hasRide =
             await Ride.userHasRideAtTimeRange(DateTimeRange(start: _selectedDate, end: endTime), driver.id!);
         if (hasRide && mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(S.of(context).pageCreateDriveYouAlreadyHaveRide)),
+          return showSnackBar(
+            context,
+            S.of(context).pageCreateDriveYouAlreadyHaveRide,
           );
-          return;
         }
 
         final Drive drive = Drive(
@@ -170,10 +171,9 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
         );
       } on AuthException {
         //todo: change error message when login is implemented
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(S.of(context).failureSnackBar),
-          ),
+        showSnackBar(
+          context,
+          S.of(context).failureSnackBar,
         );
       }
     }

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -14,6 +14,7 @@ import '../../util/locale_manager.dart';
 import '../../util/own_theme_fields.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/profile_wrap_list.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import '../../util/trip/pending_ride_card.dart';
 import '../../util/trip/trip_overview.dart';
@@ -441,11 +442,10 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
               _cancelDrive();
 
               Navigator.of(context).pop();
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(S.of(context).pageDriveDetailCancelDialogToast),
-                  duration: const Duration(seconds: 2),
-                ),
+              showSnackBar(
+                context,
+                S.of(context).pageDriveDetailCancelDialogToast,
+                durationType: SnackBarDurationType.medium,
               );
             },
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'main_app.dart';
 import 'util/locale_manager.dart';
 import 'util/search/address_suggestion_manager.dart';
+import 'util/snackbar.dart';
 import 'util/supabase.dart';
 import 'util/theme_manager.dart';
 import 'welcome/pages/reset_password_page.dart';
@@ -108,11 +109,7 @@ class _AuthAppState extends State<AuthApp> {
         if (error.runtimeType == AuthException) {
           error = error as AuthException;
           if (error.message == 'Email link is invalid or has expired') {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(S.of(context).authEmailLinkInvalid),
-              ),
-            );
+            showSnackBar(context, S.of(context).authEmailLinkInvalid);
           }
         }
       },

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -12,6 +12,7 @@ import '../../util/buttons/custom_banner.dart';
 import '../../util/chat/pages/chat_page.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/profile_wrap_list.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import '../../util/trip/trip_overview.dart';
 import '../../welcome/pages/login_page.dart';
@@ -268,11 +269,10 @@ class _RideDetailPageState extends State<RideDetailPage> {
               _cancelRide();
 
               Navigator.of(context).pop();
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(S.of(context).pageRideDetailCancelDialogToast),
-                  duration: const Duration(seconds: 2),
-                ),
+              showSnackBar(
+                context,
+                S.of(context).pageRideDetailCancelDialogToast,
+                durationType: SnackBarDurationType.medium,
               );
             },
           ),
@@ -376,11 +376,10 @@ class _RideDetailPageState extends State<RideDetailPage> {
               _withdrawRide();
 
               Navigator.of(context).pop();
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(S.of(context).pageRideDetailWithdrawDialogToast),
-                  duration: const Duration(seconds: 2),
-                ),
+              showSnackBar(
+                context,
+                S.of(context).pageRideDetailWithdrawDialogToast,
+                durationType: SnackBarDurationType.medium,
               );
             },
           ),

--- a/lib/rides/widgets/search_ride_filter.dart
+++ b/lib/rides/widgets/search_ride_filter.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../account/models/profile.dart';
@@ -8,6 +7,7 @@ import '../../account/models/profile_feature.dart';
 import '../../account/models/review.dart';
 import '../../util/profiles/reviews/custom_rating_bar.dart';
 import '../../util/profiles/reviews/custom_rating_bar_size.dart';
+import '../../util/snackbar.dart';
 import '../models/ride.dart';
 
 class SearchRideFilter {
@@ -176,12 +176,10 @@ class SearchRideFilter {
                           .firstWhereOrNull((Feature selectedFeature) => selectedFeature.isMutuallyExclusive(feature));
                       if (mutuallyExclusiveFeature != null) {
                         final String description = mutuallyExclusiveFeature.getDescription(context);
-                        final String text = S.of(context).pageProfileEditProfileFeaturesMutuallyExclusive(description);
-                        SemanticsService.announce(text, TextDirection.ltr);
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(text)),
+                        return showSnackBar(
+                          context,
+                          S.of(context).pageProfileEditProfileFeaturesMutuallyExclusive(description),
                         );
-                        return;
                       }
                       innerSetState(() => _selectedFeatures.add(feature));
                     }

--- a/lib/util/snackbar.dart
+++ b/lib/util/snackbar.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+void showSnackBar(
+  BuildContext context,
+  String message, {
+  SnackBarDurationType durationType = SnackBarDurationType.long,
+  bool replace = false,
+}) {
+  SemanticsService.announce(message, TextDirection.ltr);
+
+  if (replace) {
+    ScaffoldMessenger.of(context).clearSnackBars();
+  }
+
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(message),
+      duration: durationType.duration,
+    ),
+  );
+}
+
+enum SnackBarDurationType { short, medium, long }
+
+extension SnackBarDurationExtension on SnackBarDurationType {
+  Duration get duration {
+    switch (this) {
+      case SnackBarDurationType.short:
+        return const Duration(seconds: 1);
+      case SnackBarDurationType.medium:
+        return const Duration(seconds: 2);
+      case SnackBarDurationType.long:
+        return const Duration(seconds: 4);
+    }
+  }
+}

--- a/lib/util/trip/pending_ride_card.dart
+++ b/lib/util/trip/pending_ride_card.dart
@@ -6,6 +6,7 @@ import '../../rides/models/ride.dart';
 import '../icon_widget.dart';
 import '../locale_manager.dart';
 import '../profiles/profile_widget.dart';
+import '../snackbar.dart';
 import '../supabase.dart';
 import 'trip_card.dart';
 
@@ -124,19 +125,17 @@ class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
               if (widget.drive.isRidePossible(_ride)) {
                 approveRide();
                 Navigator.of(dialogContext).pop();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(S.of(context).cardPendingRideApproveDialogSuccessSnackbar),
-                    duration: const Duration(seconds: 2),
-                  ),
+                showSnackBar(
+                  context,
+                  S.of(context).cardPendingRideApproveDialogSuccessSnackbar,
+                  durationType: SnackBarDurationType.medium,
                 );
               } else {
                 Navigator.of(dialogContext).pop();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(S.of(context).cardPendingRideApproveDialogErrorSnackbar),
-                    duration: const Duration(seconds: 2),
-                  ),
+                showSnackBar(
+                  context,
+                  S.of(context).cardPendingRideApproveDialogErrorSnackbar,
+                  durationType: SnackBarDurationType.medium,
                 );
               }
             },
@@ -162,11 +161,10 @@ class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
             onPressed: () {
               rejectRide();
               Navigator.of(context).pop();
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(S.of(context).cardPendingRideRejectDialogSuccessSnackBar),
-                  duration: const Duration(seconds: 2),
-                ),
+              showSnackBar(
+                context,
+                S.of(context).cardPendingRideRejectDialogSuccessSnackBar,
+                durationType: SnackBarDurationType.medium,
               );
             },
           ),

--- a/lib/welcome/pages/login_page.dart
+++ b/lib/welcome/pages/login_page.dart
@@ -1,8 +1,6 @@
-import 'dart:async';
 import 'dart:core';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:progress_state_button/progress_button.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -10,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../util/buttons/loading_button.dart';
 import '../../util/fields/email_field.dart';
 import '../../util/fields/password_field.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import 'forgot_password_page.dart';
 import 'register_page.dart';
@@ -79,17 +78,13 @@ class LoginFormState extends State<LoginForm> {
 
       if (!mounted) return;
 
-      final String text = e.statusCode == '400'
+      final String message = e.statusCode == '400'
           ? e.message.contains('credentials')
               ? S.of(context).pageLoginFailureCredentials
               : S.of(context).pageLoginFailureEmailNotConfirmed
           : S.of(context).failureSnackBar;
 
-      unawaited(SemanticsService.announce(text, TextDirection.ltr));
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(text)),
-      );
+      showSnackBar(context, message);
     }
   }
 

--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -9,6 +9,7 @@ import '../../account/models/profile.dart';
 import '../../util/buttons/loading_button.dart';
 import '../../util/fields/email_field.dart';
 import '../../util/fields/password_field.dart';
+import '../../util/snackbar.dart';
 import '../../util/supabase.dart';
 import 'after_registration_page.dart';
 
@@ -95,14 +96,8 @@ class RegisterFormState extends State<RegisterForm> {
     }
   }
 
-  Future<void> showSnackBar(String text) async {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(text)),
-    );
-  }
-
   Future<void> fail() async {
-    unawaited(showSnackBar(S.of(context).failureSnackBar));
+    showSnackBar(context, S.of(context).failureSnackBar);
 
     setState(() {
       buttonState = ButtonState.fail;


### PR DESCRIPTION
This unifies the snackbar behaviour. It will always announce the message via the SemanticsService (are there cases where we do not want that @Eddie-42 ?). There are also 3 predefined lengths of visibility for the SnackBar.

Also, adds a "replace" parameter that allows to replace the whole SnackBar queue (and hiding the current SnackBar). That's especially important in the "EditProfileFeatures" page where it was previously possible to create an insanely long queue.