### PR TITLE
Better PasswordField (User study feedback)

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -38,7 +38,7 @@
   "formEmailValidateInvalid": "Bitte gib eine gültige E-Mail-Adresse ein",
   "formPassword": "Passwort",
   "formPasswordHint": "Gib dein Passwort ein",
-  "formPasswordHelper": "Mindestens 8 Zeichen, mindestens eine Zahl, mindestens ein Großbuchstabe, mindestens ein Kleinbuchstabe, mindestens ein Sonderzeichen",
+  "formPasswordChooseHint": "Wähle ein sicheres Passwort",
   "formPasswordValidateEmpty": "Bitte gib dein Passwort ein",
   "formPasswordValidateMinLength": "Passwort muss mindestens 8 Zeichen lang sein",
   "formPasswordValidateNumber": "Passwort muss mindestens eine Zahl enthalten",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -38,6 +38,7 @@
   "formEmailValidateInvalid": "Bitte gib eine gültige E-Mail-Adresse ein",
   "formPassword": "Passwort",
   "formPasswordHint": "Gib dein Passwort ein",
+  "formPasswordHelper": "Mindestens 8 Zeichen, mindestens eine Zahl, mindestens ein Großbuchstabe, mindestens ein Kleinbuchstabe, mindestens ein Sonderzeichen",
   "formPasswordValidateEmpty": "Bitte gib dein Passwort ein",
   "formPasswordValidateMinLength": "Passwort muss mindestens 8 Zeichen lang sein",
   "formPasswordValidateNumber": "Passwort muss mindestens eine Zahl enthalten",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -59,6 +59,7 @@
   "formEmailValidateInvalid": "Please enter a valid email address",
   "formPassword": "Password",
   "formPasswordHint": "Enter your password",
+  "formPasswordHelper": "Password must be at least 8 characters long and contain at least one number, one uppercase letter, one lowercase letter and one special character.",
   "formPasswordValidateEmpty": "Please enter your password",
   "formPasswordValidateMinLength": "Password must be at least 8 characters",
   "formPasswordValidateNumber": "Password must contain at least one number",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -59,7 +59,7 @@
   "formEmailValidateInvalid": "Please enter a valid email address",
   "formPassword": "Password",
   "formPasswordHint": "Enter your password",
-  "formPasswordHelper": "Password must be at least 8 characters long and contain at least one number, one uppercase letter, one lowercase letter and one special character.",
+  "formPasswordChooseHint": "Choose a secure password",
   "formPasswordValidateEmpty": "Please enter your password",
   "formPasswordValidateMinLength": "Password must be at least 8 characters",
   "formPasswordValidateNumber": "Password must contain at least one number",

--- a/lib/util/fields/password_field.dart
+++ b/lib/util/fields/password_field.dart
@@ -101,7 +101,7 @@ class _PasswordFieldState extends State<PasswordField> {
     } else if (value.length < 8) {
       return S.of(context).formPasswordValidateMinLength;
     } else if (RegExp('[0-9]').hasMatch(value) == false) {
-      return S.of(context).formPasswordValidateMinLength;
+      return S.of(context).formPasswordValidateNumber;
     } else if (RegExp('[A-Z]').hasMatch(value) == false) {
       return S.of(context).formPasswordValidateUppercase;
     } else if (RegExp('[a-z]').hasMatch(value) == false) {

--- a/lib/util/fields/password_field.dart
+++ b/lib/util/fields/password_field.dart
@@ -5,15 +5,15 @@ class PasswordField extends StatefulWidget {
   static const Key passwordFieldKey = Key('passwordField');
   static const Key passwordConfirmationFieldKey = Key('passwordConfirmationField');
 
-  final bool validateStrictly;
-  final TextEditingController? controller;
+  final TextEditingController controller;
   final TextEditingController? originalPasswordController;
+  final bool validateStrictly;
 
   const PasswordField({
     super.key,
-    this.validateStrictly = false,
+    required this.controller,
     this.originalPasswordController,
-    this.controller,
+    this.validateStrictly = false,
   }) : assert(validateStrictly == false || originalPasswordController == null);
 
   @override
@@ -31,8 +31,8 @@ class _PasswordFieldState extends State<PasswordField> {
         border: const OutlineInputBorder(),
         labelText: labelText,
         hintText: hintText,
-        helperText: widget.validateStrictly ? S.of(context).formPasswordHelper : null,
-        helperMaxLines: 3,
+        helperText: helperText,
+        helperMaxLines: 2,
         suffixIcon: IconButton(
           icon: Icon(_obscureText ? Icons.visibility : Icons.visibility_off),
           onPressed: () {
@@ -47,6 +47,7 @@ class _PasswordFieldState extends State<PasswordField> {
       autocorrect: false,
       keyboardType: TextInputType.visiblePassword,
       controller: widget.controller,
+      onChanged: (_) => setState(() {}),
       validator: validator,
     );
   }
@@ -54,7 +55,11 @@ class _PasswordFieldState extends State<PasswordField> {
   bool get isConfirmation => widget.originalPasswordController != null;
 
   String get labelText => isConfirmation ? S.of(context).formPasswordConfirm : S.of(context).formPassword;
-  String get hintText => isConfirmation ? S.of(context).formPasswordConfirmHint : S.of(context).formPasswordHint;
+  String get hintText => isConfirmation
+      ? S.of(context).formPasswordConfirmHint
+      : widget.validateStrictly
+          ? S.of(context).formPasswordChooseHint
+          : S.of(context).formPasswordHint;
 
   Key get key =>
       widget.key ?? (isConfirmation ? PasswordField.passwordConfirmationFieldKey : PasswordField.passwordFieldKey);
@@ -64,6 +69,15 @@ class _PasswordFieldState extends State<PasswordField> {
       : widget.validateStrictly
           ? _validateStrictly
           : _validateOnlyEmpty;
+
+  String? get helperText {
+    if (!widget.validateStrictly) return null;
+
+    final String text = widget.controller.text;
+    if (text.isEmpty) return null;
+
+    return _validateStrictly(text);
+  }
 
   String? _validateConfirmation(String? value) {
     if (value == null || value.isEmpty) {

--- a/lib/util/fields/password_field.dart
+++ b/lib/util/fields/password_field.dart
@@ -1,39 +1,100 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-class PasswordField extends StatelessWidget {
-  final String labelText;
-  final String hintText;
-  final String? errorText;
-  final String? helperText;
-  final String? Function(String?)? validator;
+class PasswordField extends StatefulWidget {
+  static const Key passwordFieldKey = Key('passwordField');
+  static const Key passwordConfirmationFieldKey = Key('passwordConfirmationField');
+
+  final bool validateStrictly;
   final TextEditingController? controller;
+  final TextEditingController? originalPasswordController;
 
   const PasswordField({
     super.key,
-    required this.labelText,
-    this.hintText = '',
-    this.errorText,
-    this.helperText,
+    this.validateStrictly = false,
+    this.originalPasswordController,
     this.controller,
-    this.validator,
-  });
+  }) : assert(validateStrictly == false || originalPasswordController == null);
+
+  @override
+  State<PasswordField> createState() => _PasswordFieldState();
+}
+
+class _PasswordFieldState extends State<PasswordField> {
+  bool _obscureText = true;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      key: key,
       decoration: InputDecoration(
         border: const OutlineInputBorder(),
         labelText: labelText,
         hintText: hintText,
-        errorText: errorText,
-        helperText: helperText,
+        helperText: widget.validateStrictly ? S.of(context).formPasswordHelper : null,
+        helperMaxLines: 3,
+        suffixIcon: IconButton(
+          icon: Icon(_obscureText ? Icons.visibility : Icons.visibility_off),
+          onPressed: () {
+            setState(() {
+              _obscureText = !_obscureText;
+            });
+          },
+        ),
       ),
-      obscureText: true,
+      obscureText: _obscureText,
       enableSuggestions: false,
       autocorrect: false,
       keyboardType: TextInputType.visiblePassword,
-      controller: controller,
+      controller: widget.controller,
       validator: validator,
     );
+  }
+
+  bool get isConfirmation => widget.originalPasswordController != null;
+
+  String get labelText => isConfirmation ? S.of(context).formPasswordConfirm : S.of(context).formPassword;
+  String get hintText => isConfirmation ? S.of(context).formPasswordConfirmHint : S.of(context).formPasswordHint;
+
+  Key get key =>
+      widget.key ?? (isConfirmation ? PasswordField.passwordConfirmationFieldKey : PasswordField.passwordFieldKey);
+
+  String? Function(String?) get validator => isConfirmation
+      ? _validateConfirmation
+      : widget.validateStrictly
+          ? _validateStrictly
+          : _validateOnlyEmpty;
+
+  String? _validateConfirmation(String? value) {
+    if (value == null || value.isEmpty) {
+      return S.of(context).formPasswordConfirmValidateEmpty;
+    } else if (value != widget.originalPasswordController?.text) {
+      return S.of(context).formPasswordConfirmValidateMatch;
+    }
+    return null;
+  }
+
+  String? _validateOnlyEmpty(String? value) {
+    if (value == null || value.isEmpty) {
+      return S.of(context).formPasswordValidateEmpty;
+    }
+    return null;
+  }
+
+  String? _validateStrictly(String? value) {
+    if (value == null || value.isEmpty) {
+      return S.of(context).formPasswordValidateEmpty;
+    } else if (value.length < 8) {
+      return S.of(context).formPasswordValidateMinLength;
+    } else if (RegExp('[0-9]').hasMatch(value) == false) {
+      return S.of(context).formPasswordValidateMinLength;
+    } else if (RegExp('[A-Z]').hasMatch(value) == false) {
+      return S.of(context).formPasswordValidateUppercase;
+    } else if (RegExp('[a-z]').hasMatch(value) == false) {
+      return S.of(context).formPasswordValidateLowercase;
+    } else if (RegExp('[^A-z0-9]').hasMatch(value) == false) {
+      return S.of(context).formPasswordValidateSpecial;
+    }
+    return null;
   }
 }

--- a/lib/util/fields/password_field.dart
+++ b/lib/util/fields/password_field.dart
@@ -7,14 +7,14 @@ class PasswordField extends StatefulWidget {
 
   final TextEditingController controller;
   final TextEditingController? originalPasswordController;
-  final bool validateStrictly;
+  final bool validateSecurity;
 
   const PasswordField({
     super.key,
     required this.controller,
     this.originalPasswordController,
-    this.validateStrictly = false,
-  }) : assert(validateStrictly == false || originalPasswordController == null);
+    this.validateSecurity = false,
+  }) : assert(validateSecurity == false || originalPasswordController == null);
 
   @override
   State<PasswordField> createState() => _PasswordFieldState();
@@ -57,7 +57,7 @@ class _PasswordFieldState extends State<PasswordField> {
   String get labelText => isConfirmation ? S.of(context).formPasswordConfirm : S.of(context).formPassword;
   String get hintText => isConfirmation
       ? S.of(context).formPasswordConfirmHint
-      : widget.validateStrictly
+      : widget.validateSecurity
           ? S.of(context).formPasswordChooseHint
           : S.of(context).formPasswordHint;
 
@@ -66,17 +66,17 @@ class _PasswordFieldState extends State<PasswordField> {
 
   String? Function(String?) get validator => isConfirmation
       ? _validateConfirmation
-      : widget.validateStrictly
-          ? _validateStrictly
+      : widget.validateSecurity
+          ? _validateSecurity
           : _validateOnlyEmpty;
 
   String? get helperText {
-    if (!widget.validateStrictly) return null;
+    if (!widget.validateSecurity) return null;
 
     final String text = widget.controller.text;
     if (text.isEmpty) return null;
 
-    return _validateStrictly(text);
+    return _validateSecurity(text);
   }
 
   String? _validateConfirmation(String? value) {
@@ -95,7 +95,7 @@ class _PasswordFieldState extends State<PasswordField> {
     return null;
   }
 
-  String? _validateStrictly(String? value) {
+  String? _validateSecurity(String? value) {
     if (value == null || value.isEmpty) {
       return S.of(context).formPasswordValidateEmpty;
     } else if (value.length < 8) {

--- a/lib/welcome/pages/login_page.dart
+++ b/lib/welcome/pages/login_page.dart
@@ -117,17 +117,7 @@ class LoginFormState extends State<LoginForm> {
             Expanded(child: Container()),
             EmailField(controller: emailController),
             const SizedBox(height: 15),
-            PasswordField(
-              labelText: S.of(context).formPassword,
-              hintText: S.of(context).formPasswordHint,
-              controller: passwordController,
-              validator: (String? value) {
-                if (value == null || value.isEmpty) {
-                  return S.of(context).formPasswordValidateEmpty;
-                }
-                return null;
-              },
-            ),
+            PasswordField(controller: passwordController),
             TextButton(
               key: const Key('loginForgotPasswordButton'),
               onPressed: () {

--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -145,41 +145,13 @@ class RegisterFormState extends State<RegisterForm> {
             ),
             const SizedBox(height: 15),
             PasswordField(
-              labelText: S.of(context).formPassword,
-              hintText: S.of(context).formPasswordHint,
-              key: const Key('registerPasswordField'),
               controller: passwordController,
-              validator: (String? value) {
-                if (value == null || value.isEmpty) {
-                  return S.of(context).formPasswordValidateEmpty;
-                } else if (value.length < 8) {
-                  return S.of(context).formPasswordValidateMinLength;
-                } else if (RegExp('[0-9]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateMinLength;
-                } else if (RegExp('[A-Z]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateUppercase;
-                } else if (RegExp('[a-z]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateLowercase;
-                } else if (RegExp('[^A-z0-9]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateSpecial;
-                }
-                return null;
-              },
+              validateStrictly: true,
             ),
             const SizedBox(height: 15),
             PasswordField(
-              labelText: S.of(context).formPasswordConfirm,
-              hintText: S.of(context).formPasswordConfirmHint,
-              key: const Key('registerPasswordConfirmField'),
               controller: passwordConfirmationController,
-              validator: (String? value) {
-                if (value == null || value.isEmpty) {
-                  return S.of(context).formPasswordConfirmValidateEmpty;
-                } else if (value != passwordController.text) {
-                  return S.of(context).formPasswordConfirmValidateMatch;
-                }
-                return null;
-              },
+              originalPasswordController: passwordController,
             ),
             const SizedBox(height: 15),
             Hero(

--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -146,7 +146,7 @@ class RegisterFormState extends State<RegisterForm> {
             const SizedBox(height: 15),
             PasswordField(
               controller: passwordController,
-              validateStrictly: true,
+              validateSecurity: true,
             ),
             const SizedBox(height: 15),
             PasswordField(

--- a/lib/welcome/pages/reset_password_page.dart
+++ b/lib/welcome/pages/reset_password_page.dart
@@ -81,7 +81,7 @@ class ResetPasswordFormState extends State<ResetPasswordForm> {
           children: <Widget>[
             PasswordField(
               controller: passwordController,
-              validateStrictly: true,
+              validateSecurity: true,
             ),
             const SizedBox(height: 15),
             PasswordField(

--- a/lib/welcome/pages/reset_password_page.dart
+++ b/lib/welcome/pages/reset_password_page.dart
@@ -80,41 +80,13 @@ class ResetPasswordFormState extends State<ResetPasswordForm> {
         child: Column(
           children: <Widget>[
             PasswordField(
-              labelText: S.of(context).formPassword,
-              hintText: S.of(context).pageResetPasswordHint,
               controller: passwordController,
-              key: const Key('resetPasswordPasswordField'),
-              validator: (String? value) {
-                if (value == null || value.isEmpty) {
-                  return S.of(context).pageResetPasswordValidateEmpty;
-                } else if (value.length < 8) {
-                  return S.of(context).formPasswordValidateMinLength;
-                } else if (RegExp('[0-9]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateMinLength;
-                } else if (RegExp('[A-Z]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateUppercase;
-                } else if (RegExp('[a-z]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateLowercase;
-                } else if (RegExp('[^A-z0-9]').hasMatch(value) == false) {
-                  return S.of(context).formPasswordValidateSpecial;
-                }
-                return null;
-              },
+              validateStrictly: true,
             ),
             const SizedBox(height: 15),
             PasswordField(
-              labelText: S.of(context).formPasswordConfirm,
-              hintText: S.of(context).pageResetPasswordConfirmHint,
               controller: passwordConfirmationController,
-              key: const Key('resetPasswordPasswordConfirmField'),
-              validator: (String? value) {
-                if (value == null || value.isEmpty) {
-                  return S.of(context).pageResetPasswordConfirmValidateEmpty;
-                } else if (value != passwordController.text) {
-                  return S.of(context).formPasswordConfirmValidateMatch;
-                }
-                return null;
-              },
+              originalPasswordController: passwordController,
             ),
             const SizedBox(height: 15),
             LoadingButton(

--- a/test/widgets/util/password_field_test.dart
+++ b/test/widgets/util/password_field_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:motis_mitfahr_app/util/fields/password_field.dart';
+
+import '../../util/pump_material.dart';
+
+void main() {
+  group('PasswordField', () {
+    final Finder passwordFieldFinder = find.descendant(
+      of: find.byType(PasswordField),
+      matching: find.byType(TextFormField),
+    );
+
+    const String invalidPassword = 'abcdefg';
+    const String validPassword = 'abc&EFG0';
+
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    late TextEditingController controller;
+
+    setUp(() {
+      controller = TextEditingController();
+    });
+
+    testWidgets('Validates the password (only empty by default)', (WidgetTester tester) async {
+      await pumpForm(tester, PasswordField(controller: controller), formKey: formKey);
+
+      final FormFieldState passwordField = tester.state(passwordFieldFinder);
+
+      // Not validated yet, so no error
+      expect(passwordField.hasError, isFalse);
+
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // Empty, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, 'abcdefg');
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // Not empty, so no error
+      expect(passwordField.hasError, isFalse);
+    });
+
+    testWidgets('Validates the password strictly if wanted', (WidgetTester tester) async {
+      await pumpForm(tester, PasswordField(controller: controller, validateStrictly: true), formKey: formKey);
+
+      final FormFieldState passwordField = tester.state(passwordFieldFinder);
+
+      // Not validated yet, so no error
+      expect(passwordField.hasError, isFalse);
+
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // Empty, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, 'abcdefg');
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // Too short, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, 'abcdefgh');
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // No number, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, 'abcdefg0');
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // No capital letters, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, 'ABCDEFG0');
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // No lower letters, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, 'abcdEFG0');
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // No special, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, validPassword);
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      expect(passwordField.hasError, isFalse);
+    });
+
+    testWidgets('Validates the password as confirmation', (WidgetTester tester) async {
+      final TextEditingController originalController = TextEditingController(text: invalidPassword);
+
+      await pumpForm(
+        tester,
+        PasswordField(controller: controller, originalPasswordController: originalController),
+        formKey: formKey,
+      );
+
+      final FormFieldState passwordField = tester.state(passwordFieldFinder);
+
+      // Not validated yet, so no error
+      expect(passwordField.hasError, isFalse);
+
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // Empty, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, validPassword);
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // Not the same, so error
+      expect(passwordField.hasError, isTrue);
+
+      await tester.enterText(passwordFieldFinder, invalidPassword);
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      // The same, so no error
+      expect(passwordField.hasError, isFalse);
+    });
+
+    testWidgets('Can toggle visibility of entered text', (WidgetTester tester) async {
+      await pumpForm(tester, PasswordField(controller: controller), formKey: formKey);
+
+      final Finder innerTextFieldFinder = find.descendant(
+        of: passwordFieldFinder,
+        matching: find.byType(TextField),
+      );
+
+      TextField innerTextField = tester.widget(innerTextFieldFinder);
+      expect(innerTextField.obscureText, isTrue);
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pumpAndSettle();
+
+      innerTextField = tester.widget(innerTextFieldFinder);
+      expect(innerTextField.obscureText, isFalse);
+    });
+
+    testWidgets('It is impossible to have confirmation AND strict validation', (WidgetTester tester) async {
+      expect(() async {
+        await pumpForm(
+          tester,
+          PasswordField(
+            controller: controller,
+            originalPasswordController: TextEditingController(),
+            validateStrictly: true,
+          ),
+          formKey: formKey,
+        );
+      }, throwsAssertionError);
+    });
+  });
+}

--- a/test/widgets/util/password_field_test.dart
+++ b/test/widgets/util/password_field_test.dart
@@ -42,7 +42,7 @@ void main() {
     });
 
     testWidgets('Validates the password strictly if wanted', (WidgetTester tester) async {
-      await pumpForm(tester, PasswordField(controller: controller, validateStrictly: true), formKey: formKey);
+      await pumpForm(tester, PasswordField(controller: controller, validateSecurity: true), formKey: formKey);
 
       final FormFieldState passwordField = tester.state(passwordFieldFinder);
 
@@ -151,7 +151,7 @@ void main() {
           PasswordField(
             controller: controller,
             originalPasswordController: TextEditingController(),
-            validateStrictly: true,
+            validateSecurity: true,
           ),
           formKey: formKey,
         );

--- a/test/widgets/util/password_field_test.dart
+++ b/test/widgets/util/password_field_test.dart
@@ -135,9 +135,13 @@ void main() {
 
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-
       innerTextField = tester.widget(innerTextFieldFinder);
       expect(innerTextField.obscureText, isFalse);
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pumpAndSettle();
+      innerTextField = tester.widget(innerTextFieldFinder);
+      expect(innerTextField.obscureText, isTrue);
     });
 
     testWidgets('It is impossible to have confirmation AND strict validation', (WidgetTester tester) async {

--- a/test/widgets/welcome/login_page_test.dart
+++ b/test/widgets/welcome/login_page_test.dart
@@ -29,10 +29,7 @@ void main() {
       of: find.byType(EmailField),
       matching: find.byType(TextFormField),
     );
-    final Finder passwordFieldFinder = find.descendant(
-      of: find.byType(PasswordField),
-      matching: find.byType(TextFormField),
-    );
+    final Finder passwordFieldFinder = find.byKey(PasswordField.passwordFieldKey);
     final Finder loginButtonFinder = find.byType(LoadingButton);
 
     testWidgets('Shows the login page', (WidgetTester tester) async {
@@ -49,27 +46,9 @@ void main() {
     testWidgets('Validates the password (not so strictly)', (WidgetTester tester) async {
       await pumpMaterial(tester, const LoginPage());
 
-      final LoginFormState formState = tester.state(find.byType(LoginForm));
+      final PasswordField passwordField = tester.widget(find.byType(PasswordField));
 
-      final FormFieldState passwordField = tester.state(passwordFieldFinder);
-
-      // Not validated yet, so no error
-      expect(passwordField.hasError, isFalse);
-
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // Empty, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, 'abcdefg');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      expect(passwordField.hasError, isFalse);
-
-      await tester.enterText(passwordFieldFinder, password);
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      expect(passwordField.hasError, isFalse);
+      expect(passwordField.validateStrictly, isFalse);
     });
 
     testWidgets('Navigates to the forgotPassword page', (WidgetTester tester) async {

--- a/test/widgets/welcome/login_page_test.dart
+++ b/test/widgets/welcome/login_page_test.dart
@@ -48,7 +48,7 @@ void main() {
 
       final PasswordField passwordField = tester.widget(find.byType(PasswordField));
 
-      expect(passwordField.validateStrictly, isFalse);
+      expect(passwordField.validateSecurity, isFalse);
     });
 
     testWidgets('Navigates to the forgotPassword page', (WidgetTester tester) async {

--- a/test/widgets/welcome/register_page_test.dart
+++ b/test/widgets/welcome/register_page_test.dart
@@ -76,7 +76,7 @@ void main() {
         find.ancestor(of: passwordFieldFinder, matching: find.byType(PasswordField)),
       );
 
-      expect(passwordField.validateStrictly, isTrue);
+      expect(passwordField.validateSecurity, isTrue);
     });
 
     testWidgets('Validates the password confirmation', (WidgetTester tester) async {

--- a/test/widgets/welcome/reset_password_page_test.dart
+++ b/test/widgets/welcome/reset_password_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:motis_mitfahr_app/util/buttons/loading_button.dart';
+import 'package:motis_mitfahr_app/util/fields/password_field.dart';
 import 'package:motis_mitfahr_app/util/supabase.dart';
 import 'package:motis_mitfahr_app/welcome/pages/reset_password_page.dart';
 import 'package:progress_state_button/progress_button.dart';
@@ -51,14 +52,8 @@ void main() {
   });
 
   group('ResetPasswordPage', () {
-    final Finder passwordFieldFinder = find.descendant(
-      of: find.byKey(const Key('resetPasswordPasswordField')),
-      matching: find.byType(TextFormField),
-    );
-    final Finder passwordConfirmFieldFinder = find.descendant(
-      of: find.byKey(const Key('resetPasswordPasswordConfirmField')),
-      matching: find.byType(TextFormField),
-    );
+    final Finder passwordFieldFinder = find.byKey(PasswordField.passwordFieldKey);
+    final Finder passwordConfirmFieldFinder = find.byKey(PasswordField.passwordConfirmationFieldKey);
     final Finder resetPasswordButtonFinder = find.byType(LoadingButton);
 
     testWidgets('Shows the password form', (WidgetTester tester) async {
@@ -76,81 +71,22 @@ void main() {
     testWidgets('Validates the password', (WidgetTester tester) async {
       await pumpMaterial(tester, ResetPasswordPage(onPasswordReset: onPasswordReset));
 
-      final ResetPasswordFormState formState = tester.state(find.byType(ResetPasswordForm));
+      final PasswordField passwordField = tester.widget(
+        find.ancestor(of: passwordFieldFinder, matching: find.byType(PasswordField)),
+      );
 
-      final FormFieldState passwordField = tester.state(passwordFieldFinder);
-
-      // Not validated yet, so no error
-      expect(passwordField.hasError, isFalse);
-
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // Empty, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, 'abcdefg');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // Too short, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, 'abcdefgh');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // No number, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, 'abcdefg0');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // No capital letters, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, 'ABCDEFG0');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // No lower letters, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, 'abcdEFG0');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // No special, so error
-      expect(passwordField.hasError, isTrue);
-
-      await tester.enterText(passwordFieldFinder, password);
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      expect(passwordField.hasError, isFalse);
+      expect(passwordField.validateStrictly, isTrue);
     });
 
     testWidgets('Validates the password confirmation', (WidgetTester tester) async {
       await pumpMaterial(tester, ResetPasswordPage(onPasswordReset: onPasswordReset));
+      await tester.enterText(passwordFieldFinder, 'abc&EFG0');
 
-      final ResetPasswordFormState formState = tester.state(find.byType(ResetPasswordForm));
-      await tester.enterText(passwordFieldFinder, password);
+      final PasswordField passwordConfirmationField = tester.widget(
+        find.ancestor(of: passwordConfirmFieldFinder, matching: find.byType(PasswordField)),
+      );
 
-      final FormFieldState passwordConfirmationField = tester.state(passwordConfirmFieldFinder);
-
-      // Not validated yet, so no error
-      expect(passwordConfirmationField.hasError, isFalse);
-
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // Empty, so error
-      expect(passwordConfirmationField.hasError, isTrue);
-
-      await tester.enterText(passwordConfirmFieldFinder, '${password}a');
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // Not the same, so error
-      expect(passwordConfirmationField.hasError, isTrue);
-
-      await tester.enterText(passwordConfirmFieldFinder, password);
-      formState.formKey.currentState!.validate();
-      await tester.pumpAndSettle();
-      // Same, so no error
-      expect(passwordConfirmationField.hasError, isFalse);
+      expect(passwordConfirmationField.originalPasswordController!.text, 'abc&EFG0');
     });
 
     group('submitting the form', () {

--- a/test/widgets/welcome/reset_password_page_test.dart
+++ b/test/widgets/welcome/reset_password_page_test.dart
@@ -75,7 +75,7 @@ void main() {
         find.ancestor(of: passwordFieldFinder, matching: find.byType(PasswordField)),
       );
 
-      expect(passwordField.validateStrictly, isTrue);
+      expect(passwordField.validateSecurity, isTrue);
     });
 
     testWidgets('Validates the password confirmation', (WidgetTester tester) async {


### PR DESCRIPTION
- Main thing: Add a toggle button for obscuring the password. This also required the widget to become stateful, of course.
- Refactor the PasswordField because the validator logic was always one of three things. Now the pages just need to say whether they want to validate strictly (Reset + Register vs. Login) and if the password is a confirmation field (by providing the controller of the original password field)
- Adds a HelperText for the strictly validating fields to make the requirements more clear. It actually updates on change and always tells you the next requirement to fulfill.
- Refactor the tests into their own file because there was a lot of duplication (only possible now that the logic actually resides inside the widget but I remember @istzen asking for it on the original PR)

I also saw that it is possible to do form validation on user input, is that something we should maybe do?