### PR TITLE
Enable remaining analysis rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,7 +12,7 @@ linter:
     - always_specify_types
     - annotate_overrides
     - avoid_bool_literals_in_conditional_expressions
-    # - avoid_classes_with_only_static_members # ENABLE IN THE FUTURE
+    - avoid_classes_with_only_static_members
     - avoid_double_and_int_checks
     - avoid_dynamic_calls
     - avoid_empty_else
@@ -163,7 +163,7 @@ linter:
     - use_named_constants
     - use_raw_strings
     - use_rethrow_when_possible
-    # - use_setters_to_change_properties # ENABLE LATER
+    - use_setters_to_change_properties
     - use_super_parameters
     - use_test_throws_matchers
     - use_to_and_as_if_applicable

--- a/lib/account/models/profile.dart
+++ b/lib/account/models/profile.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../util/model.dart';
 import '../../util/parse_helper.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import 'profile_feature.dart';
 import 'report.dart';
 import 'review.dart';
@@ -49,7 +49,7 @@ class Profile extends Model {
     return '';
   }
 
-  bool get isCurrentUser => id == SupabaseManager.getCurrentProfile()?.id;
+  bool get isCurrentUser => id == supabaseManager.currentProfile?.id;
 
   List<Feature>? get features =>
       profileFeatures?.map((ProfileFeature profileFeature) => profileFeature.feature).toList();

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../util/locale_manager.dart';
 import '../../util/profiles/profile_widget.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/theme_manager.dart';
 import 'about_page.dart';
 import 'help_page.dart';
@@ -106,7 +106,7 @@ class _AccountPageState extends State<AccountPage> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 5),
             child: ProfileWidget(
-              SupabaseManager.getCurrentProfile()!,
+              supabaseManager.currentProfile!,
               size: 25,
               actionWidget: const Icon(Icons.chevron_right),
               onPop: (_) => setState(() {}),

--- a/lib/account/pages/edit_account/edit_birth_date_page.dart
+++ b/lib/account/pages/edit_account/edit_birth_date_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
 import '../../../util/locale_manager.dart';
-import '../../../util/supabase.dart';
+import '../../../util/supabase_manager.dart';
 import '../../models/profile.dart';
 
 class EditBirthDatePage extends StatefulWidget {
@@ -88,10 +88,10 @@ class _EditBirthDatePageState extends State<EditBirthDatePage> {
 
   Future<void> onPressed() async {
     final String? date = _date == null ? null : _date!.toString();
-    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
+    await supabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'birth_date': date,
     }).eq('id', widget.profile.id);
-    await SupabaseManager.reloadCurrentProfile();
+    await supabaseManager.reloadCurrentProfile();
 
     if (mounted) Navigator.of(context).pop();
   }

--- a/lib/account/pages/edit_account/edit_description_page.dart
+++ b/lib/account/pages/edit_account/edit_description_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
-import '../../../util/supabase.dart';
+import '../../../util/supabase_manager.dart';
 import '../../models/profile.dart';
 
 class EditDescriptionPage extends StatefulWidget {
@@ -68,10 +68,10 @@ class _EditDescriptionPageState extends State<EditDescriptionPage> {
 
   Future<void> onPressed() async {
     final String? text = _controller.text == '' ? null : _controller.text;
-    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
+    await supabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'description': text,
     }).eq('id', widget.profile.id);
-    await SupabaseManager.reloadCurrentProfile();
+    await supabaseManager.reloadCurrentProfile();
 
     if (mounted) Navigator.of(context).pop();
   }

--- a/lib/account/pages/edit_account/edit_full_name_page.dart
+++ b/lib/account/pages/edit_account/edit_full_name_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
-import '../../../util/supabase.dart';
+import '../../../util/supabase_manager.dart';
 import '../../models/profile.dart';
 
 class EditFullNamePage extends StatefulWidget {
@@ -79,11 +79,11 @@ class _EditFullNamePageState extends State<EditFullNamePage> {
   Future<void> onPressed() async {
     final String? surname = _surnameController.text == '' ? null : _surnameController.text;
     final String? name = _nameController.text == '' ? null : _nameController.text;
-    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
+    await supabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'surname': surname,
       'name': name,
     }).eq('id', widget.profile.id);
-    await SupabaseManager.reloadCurrentProfile();
+    await supabaseManager.reloadCurrentProfile();
 
     if (mounted) Navigator.of(context).pop();
   }

--- a/lib/account/pages/edit_account/edit_gender_page.dart
+++ b/lib/account/pages/edit_account/edit_gender_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
-import '../../../util/supabase.dart';
+import '../../../util/supabase_manager.dart';
 import '../../models/profile.dart';
 
 class EditGenderPage extends StatefulWidget {
@@ -75,10 +75,10 @@ class _EditGenderPageState extends State<EditGenderPage> {
   }
 
   Future<void> onPressed() async {
-    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
+    await supabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'gender': _gender?.index,
     }).eq('id', widget.profile.id);
-    await SupabaseManager.reloadCurrentProfile();
+    await supabaseManager.reloadCurrentProfile();
 
     if (mounted) Navigator.of(context).pop();
   }

--- a/lib/account/pages/edit_account/edit_profile_features_page.dart
+++ b/lib/account/pages/edit_account/edit_profile_features_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
 import '../../../util/snackbar.dart';
-import '../../../util/supabase.dart';
+import '../../../util/supabase_manager.dart';
 import '../../models/profile.dart';
 import '../../models/profile_feature.dart';
 
@@ -218,13 +218,13 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
       final Feature feature = _features[index];
 
       if (!previousFeatures.contains(feature)) {
-        await SupabaseManager.supabaseClient.from('profile_features').insert(<String, dynamic>{
+        await supabaseManager.supabaseClient.from('profile_features').insert(<String, dynamic>{
           'profile_id': widget.profile.id,
           'feature': feature.index,
           'rank': index,
         });
       } else {
-        await SupabaseManager.supabaseClient
+        await supabaseManager.supabaseClient
             .from('profile_features')
             .update(<String, dynamic>{'rank': index})
             .eq('profile_id', widget.profile.id)
@@ -233,7 +233,7 @@ class _EditProfileFeaturesPageState extends State<EditProfileFeaturesPage> {
     }
     final List<Feature> removedFeatures = previousFeatures.where((Feature e) => !_features.contains(e)).toList();
     for (final Feature feature in removedFeatures) {
-      await SupabaseManager.supabaseClient
+      await supabaseManager.supabaseClient
           .from('profile_features')
           .delete()
           .eq('profile_id', widget.profile.id)

--- a/lib/account/pages/edit_account/edit_username_page.dart
+++ b/lib/account/pages/edit_account/edit_username_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../util/buttons/button.dart';
-import '../../../util/supabase.dart';
+import '../../../util/supabase_manager.dart';
 import '../../models/profile.dart';
 
 class EditUsernamePage extends StatefulWidget {
@@ -80,10 +80,10 @@ class _EditUsernamePageState extends State<EditUsernamePage> {
     if (!_formKey.currentState!.validate()) {
       return;
     }
-    await SupabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
+    await supabaseManager.supabaseClient.from('profiles').update(<String, dynamic>{
       'username': _controller.text,
     }).eq('id', widget.profile.id);
-    await SupabaseManager.reloadCurrentProfile();
+    await supabaseManager.reloadCurrentProfile();
 
     if (mounted) Navigator.of(context).pop();
   }

--- a/lib/account/pages/help_page.dart
+++ b/lib/account/pages/help_page.dart
@@ -4,7 +4,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../config.dart';
 import '../../util/buttons/button.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 
 class HelpPage extends StatefulWidget {
   const HelpPage({super.key});
@@ -98,7 +98,7 @@ class _HelpPageState extends State<HelpPage> {
                   S.of(context).pageHelpContactUs,
                   onPressed: () => launchUrlString(
                     'mailto:${Config.emailAddress}?'
-                    'subject=${S.of(context).pageHelpEmailSubject(SupabaseManager.getCurrentProfile()!.id!)}',
+                    'subject=${S.of(context).pageHelpEmailSubject(supabaseManager.currentProfile!.id!)}',
                   ),
                 ),
               ],

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -7,7 +7,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../util/buttons/button.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../models/profile.dart';
 import '../models/report.dart';
 import '../widgets/avatar.dart';
@@ -46,7 +46,7 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> loadProfile() async {
-    final Map<String, dynamic> data = await SupabaseManager.supabaseClient.from('profiles').select('''
+    final Map<String, dynamic> data = await supabaseManager.supabaseClient.from('profiles').select('''
       *,
       profile_features (*),
       reviews_received: reviews!reviews_receiver_id_fkey(
@@ -270,7 +270,7 @@ class _ProfilePageState extends State<ProfilePage> {
       widgets.add(buildReviews());
       if (!_profile!.isCurrentUser) {
         final bool hasRecentReport = _profile!.reportsReceived!
-            .any((Report report) => report.isRecent && report.reporterId == SupabaseManager.getCurrentProfile()!.id);
+            .any((Report report) => report.isRecent && report.reporterId == supabaseManager.currentProfile!.id);
 
         widgets.addAll(<Widget>[
           const SizedBox(height: 32),
@@ -383,21 +383,21 @@ class _ProfilePageState extends State<ProfilePage> {
       final String fileExt = imageFile.path.split('.').last;
       final String fileName = '${DateTime.now().toIso8601String()}.$fileExt';
 
-      await SupabaseManager.supabaseClient.storage.from('avatars').uploadBinary(
+      await supabaseManager.supabaseClient.storage.from('avatars').uploadBinary(
             fileName,
             bytes,
             fileOptions: FileOptions(contentType: imageFile.mimeType),
           );
 
-      final String imageUrlResponse = await SupabaseManager.supabaseClient.storage
+      final String imageUrlResponse = await supabaseManager.supabaseClient.storage
           .from('avatars')
           .createSignedUrl(fileName, 60 * 60 * 24 * 365 * 10);
 
-      await SupabaseManager.supabaseClient
+      await supabaseManager.supabaseClient
           .from('profiles')
           .update(<String, dynamic>{'avatar_url': imageUrlResponse}).eq('id', _profile!.id);
 
-      await SupabaseManager.reloadCurrentProfile();
+      await supabaseManager.reloadCurrentProfile();
       await loadProfile();
     } catch (error) {
       if (mounted) {
@@ -410,16 +410,16 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> _deleteProfilePicture() async {
-    await SupabaseManager.supabaseClient
+    await supabaseManager.supabaseClient
         .from('profiles')
         .update(<String, dynamic>{'avatar_url': null}).eq('id', _profile!.id);
 
-    await SupabaseManager.reloadCurrentProfile();
+    await supabaseManager.reloadCurrentProfile();
     await loadProfile();
   }
 
   void signOut() {
-    SupabaseManager.supabaseClient.auth.signOut();
+    supabaseManager.supabaseClient.auth.signOut();
   }
 }
 

--- a/lib/account/pages/reviews_page.dart
+++ b/lib/account/pages/reviews_page.dart
@@ -6,7 +6,7 @@ import '../../util/buttons/button.dart';
 import '../../util/parse_helper.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/reviews/aggregate_review_widget.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../models/profile.dart';
 import '../models/review.dart';
 import '../widgets/review_detail.dart';
@@ -42,17 +42,17 @@ class _ReviewsPageState extends State<ReviewsPage> {
   }
 
   Future<void> load() async {
-    final Map<String, dynamic> profileData = await SupabaseManager.supabaseClient.from('profiles').select('''
+    final Map<String, dynamic> profileData = await supabaseManager.supabaseClient.from('profiles').select('''
       *,
       reviews_received: reviews!reviews_receiver_id_fkey(
         *,
         writer: writer_id(*)
       )''').eq('id', _profileId).single();
     final List<Map<String, dynamic>> commonRidesData = parseHelper.parseListOfMaps(
-      await SupabaseManager.supabaseClient.from('rides').select('''
+      await supabaseManager.supabaseClient.from('rides').select('''
           *,
           drive: drives!inner(*)
-        ''').eq('rider_id', SupabaseManager.getCurrentProfile()!.id).eq('drive.driver_id', _profileId),
+        ''').eq('rider_id', supabaseManager.currentProfile!.id).eq('drive.driver_id', _profileId),
     );
 
     setState(() {

--- a/lib/account/pages/write_report_page.dart
+++ b/lib/account/pages/write_report_page.dart
@@ -4,7 +4,7 @@ import 'package:progress_state_button/progress_button.dart';
 
 import '../../util/buttons/loading_button.dart';
 import '../../util/profiles/profile_widget.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../models/profile.dart';
 import '../models/report.dart';
 
@@ -118,12 +118,12 @@ class _WriteReportPageState extends State<WriteReportPage> {
 
     final Report report = Report(
       offenderId: widget.profile.id!,
-      reporterId: SupabaseManager.getCurrentProfile()!.id!,
+      reporterId: supabaseManager.currentProfile!.id!,
       category: _category!,
       text: _textController.text,
     );
 
-    await SupabaseManager.supabaseClient.from('reports').insert(report.toJson());
+    await supabaseManager.supabaseClient.from('reports').insert(report.toJson());
 
     setState(() {
       _state = ButtonState.success;

--- a/lib/account/pages/write_review_page.dart
+++ b/lib/account/pages/write_review_page.dart
@@ -7,7 +7,7 @@ import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/reviews/custom_rating_bar.dart';
 import '../../util/profiles/reviews/custom_rating_bar_size.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../models/profile.dart';
 import '../models/review.dart';
 
@@ -39,11 +39,11 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
   }
 
   Future<void> loadReview() async {
-    final Map<String, dynamic>? data = await SupabaseManager.supabaseClient
+    final Map<String, dynamic>? data = await supabaseManager.supabaseClient
         .from('reviews')
         .select('*')
         .eq('receiver_id', widget.profile.id)
-        .eq('writer_id', SupabaseManager.getCurrentProfile()!.id)
+        .eq('writer_id', supabaseManager.currentProfile!.id)
         .limit(1)
         .maybeSingle();
     setState(() {
@@ -51,7 +51,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
           ? Review.fromJson(data)
           : Review(
               rating: 0,
-              writerId: SupabaseManager.getCurrentProfile()!.id!,
+              writerId: supabaseManager.currentProfile!.id!,
               receiverId: widget.profile.id!,
             );
       if (_review!.text != null) _textController.text = _review!.text!;
@@ -203,9 +203,9 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
       _state = ButtonState.loading;
     });
     if (_review!.id == null) {
-      await SupabaseManager.supabaseClient.from('reviews').insert(_review!.toJson());
+      await supabaseManager.supabaseClient.from('reviews').insert(_review!.toJson());
     } else {
-      await SupabaseManager.supabaseClient.from('reviews').update(_review!.toJson()).eq('id', _review!.id);
+      await supabaseManager.supabaseClient.from('reviews').update(_review!.toJson()).eq('id', _review!.id);
     }
     setState(() {
       _state = ButtonState.success;

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -4,7 +4,7 @@ import '../../account/models/profile.dart';
 import '../../rides/models/ride.dart';
 import '../../util/parse_helper.dart';
 import '../../util/search/position.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/trip.dart';
 
 class Drive extends Trip {
@@ -80,7 +80,7 @@ class Drive extends Trip {
 
   static Future<bool> userHasDriveAtTimeRange(DateTimeRange range, int userId) async {
     final List<Map<String, dynamic>> data = parseHelper.parseListOfMaps(
-      await SupabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId),
+      await supabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId),
     );
     List<Drive> drives = Drive.fromJsonList(data);
     drives = drives.where((Drive drive) => !drive.cancelled && !drive.isFinished).toList();
@@ -146,7 +146,7 @@ class Drive extends Trip {
 
   Future<void> cancel() async {
     cancelled = true;
-    await SupabaseManager.supabaseClient.from('drives').update(<String, dynamic>{'cancelled': true}).eq('id', id);
+    await supabaseManager.supabaseClient.from('drives').update(<String, dynamic>{'cancelled': true}).eq('id', id);
     //the rides get updated automatically by a supabase function.
   }
 

--- a/lib/drives/pages/create_drive_page.dart
+++ b/lib/drives/pages/create_drive_page.dart
@@ -10,7 +10,7 @@ import '../../util/locale_manager.dart';
 import '../../util/search/address_suggestion.dart';
 import '../../util/search/start_destination_timeline.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/trip.dart';
 import '../models/drive.dart';
 import '../pages/drive_detail_page.dart';
@@ -122,7 +122,7 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
           _selectedDate.hour + 2,
           _selectedDate.minute,
         );
-        final Profile driver = SupabaseManager.getCurrentProfile()!;
+        final Profile driver = supabaseManager.currentProfile!;
 
         final bool hasDrive =
             await Drive.userHasDriveAtTimeRange(DateTimeRange(start: _selectedDate, end: endTime), driver.id!);
@@ -153,7 +153,7 @@ class _CreateDriveFormState extends State<CreateDriveForm> {
           endTime: endTime,
         );
 
-        await SupabaseManager.supabaseClient
+        await supabaseManager.supabaseClient
             .from('drives')
             .insert(drive.toJson())
             .select<Map<String, dynamic>>()

--- a/lib/drives/pages/drive_chat_page.dart
+++ b/lib/drives/pages/drive_chat_page.dart
@@ -6,7 +6,7 @@ import '../../rides/models/ride.dart';
 import '../../util/chat/models/chat.dart';
 import '../../util/chat/models/message.dart';
 import '../../util/chat/pages/chat_page.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../models/drive.dart';
 
 class DriveChatPage extends StatefulWidget {
@@ -27,7 +27,7 @@ class _DriveChatPageState extends State<DriveChatPage> {
 
     final List<int> ids = _ridesWithChat.map((Ride ride) => ride.chatId!).toList();
     _messagesStream =
-        SupabaseManager.supabaseClient.from('messages').stream(primaryKey: <String>['id']).order('created_at').map(
+        supabaseManager.supabaseClient.from('messages').stream(primaryKey: <String>['id']).order('created_at').map(
               (List<Map<String, dynamic>> messages) => Message.fromJsonList(
                 messages.where((Map<String, dynamic> element) => ids.contains(element['chat_id'])).toList(),
               ),

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -15,7 +15,7 @@ import '../../util/own_theme_fields.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/profile_wrap_list.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/pending_ride_card.dart';
 import '../../util/trip/trip_overview.dart';
 import '../models/drive.dart';
@@ -48,7 +48,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   Future<void> loadDrive() async {
-    final Map<String, dynamic> data = await SupabaseManager.supabaseClient.from('drives').select('''
+    final Map<String, dynamic> data = await supabaseManager.supabaseClient.from('drives').select('''
       *,
       rides(
         *,
@@ -144,7 +144,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
       }
 
       final Widget timeline = FixedTimeline.tileBuilder(
-        theme: CustomTimelineThemeForBuilder.of(context),
+        theme: CustomTimelineTheme.of(context, forBuilder: true),
         builder: TimelineTileBuilder.connected(
           connectionDirection: ConnectionDirection.before,
           indicatorBuilder: (BuildContext context, int index) => const CustomOutlinedDotIndicator(),
@@ -395,7 +395,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   Future<void> hideDrive() async {
-    await SupabaseManager.supabaseClient
+    await supabaseManager.supabaseClient
         .from('drives')
         .update(<String, dynamic>{'hide_in_list_view': true}).eq('id', widget.drive!.id);
   }

--- a/lib/drives/pages/drives_page.dart
+++ b/lib/drives/pages/drives_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/trip_page_builder.dart';
 import '../models/drive.dart';
 import 'create_drive_page.dart';
@@ -17,8 +17,8 @@ class _DrivesPageState extends State<DrivesPage> {
 
   @override
   void initState() {
-    final int userId = SupabaseManager.getCurrentProfile()!.id!;
-    _drives = SupabaseManager.supabaseClient
+    final int userId = supabaseManager.currentProfile!.id!;
+    _drives = supabaseManager.supabaseClient
         .from('drives')
         .stream(primaryKey: <String>['id'])
         .eq('driver_id', userId)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'main_app.dart';
 import 'util/locale_manager.dart';
-import 'util/search/address_suggestion_manager.dart';
-import 'util/supabase.dart';
+import 'util/supabase_manager.dart';
 import 'util/theme_manager.dart';
 import 'welcome/pages/reset_password_page.dart';
 import 'welcome/pages/welcome_page.dart';
@@ -17,14 +16,9 @@ void main() async {
   await dotenv.load();
 
   WidgetsFlutterBinding.ensureInitialized();
-  await Supabase.initialize(
-    url: dotenv.get('SUPABASE_BASE_URL'),
-    anonKey: dotenv.get('SUPABASE_BASE_KEY'),
-  );
-  await SupabaseManager.reloadCurrentProfile();
+  await supabaseManager.initialize();
   await themeManager.loadTheme();
   await localeManager.loadCurrentLocale();
-  await addressSuggestionManager.loadHistorySuggestions();
 
   runApp(const AppWrapper());
 }
@@ -73,7 +67,7 @@ class AuthApp extends StatefulWidget {
 
 class AuthAppState extends State<AuthApp> {
   late final StreamSubscription<AuthState> _authStateSubscription;
-  bool _isLoggedIn = SupabaseManager.supabaseClient.auth.currentSession != null;
+  bool _isLoggedIn = supabaseManager.supabaseClient.auth.currentSession != null;
   bool _resettingPassword = false;
 
   @override
@@ -84,11 +78,11 @@ class AuthAppState extends State<AuthApp> {
   }
 
   void _setupAuthStateSubscription() {
-    _authStateSubscription = SupabaseManager.supabaseClient.auth.onAuthStateChange.listen(
+    _authStateSubscription = supabaseManager.supabaseClient.auth.onAuthStateChange.listen(
       (AuthState data) async {
         final AuthChangeEvent event = data.event;
         final Session? session = data.session;
-        await SupabaseManager.reloadCurrentProfile();
+        await supabaseManager.reloadCurrentProfile();
 
         setState(() {
           _isLoggedIn = session != null;

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -5,7 +5,7 @@ import '../../drives/models/drive.dart';
 import '../../util/chat/models/chat.dart';
 import '../../util/parse_helper.dart';
 import '../../util/search/position.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/trip.dart';
 
 class Ride extends Trip {
@@ -123,7 +123,7 @@ class Ride extends Trip {
 
   static Future<bool> userHasRideAtTimeRange(DateTimeRange range, int userId) async {
     final List<Map<String, dynamic>> jsonList = parseHelper.parseListOfMaps(
-      await SupabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId),
+      await supabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId),
     );
     final List<Ride> rides =
         Ride.fromJsonList(jsonList).where((Ride ride) => ride.status.isApproved() && !ride.isFinished).toList();
@@ -159,12 +159,12 @@ class Ride extends Trip {
 
   Future<void> cancel() async {
     status = RideStatus.cancelledByRider;
-    await SupabaseManager.supabaseClient.from('rides').update(<String, dynamic>{'status': status.index}).eq('id', id);
+    await supabaseManager.supabaseClient.from('rides').update(<String, dynamic>{'status': status.index}).eq('id', id);
   }
 
   Future<void> withdraw() async {
     status = RideStatus.withdrawnByRider;
-    await SupabaseManager.supabaseClient
+    await supabaseManager.supabaseClient
         .from('rides')
         .update(<String, dynamic>{'status': status.index, 'hide_in_list_view': true}).eq('id', id);
   }

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -13,7 +13,7 @@ import '../../util/chat/pages/chat_page.dart';
 import '../../util/profiles/profile_widget.dart';
 import '../../util/profiles/profile_wrap_list.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/trip_overview.dart';
 import '../../welcome/pages/login_page.dart';
 import '../../welcome/pages/register_page.dart';
@@ -78,13 +78,13 @@ class _RideDetailPageState extends State<RideDetailPage> {
       ride = _ride!;
 
       final Map<String, dynamic> data =
-          await SupabaseManager.supabaseClient.from('drives').select(_driveQuery).eq('id', ride.driveId).single();
+          await supabaseManager.supabaseClient.from('drives').select(_driveQuery).eq('id', ride.driveId).single();
 
       ride.drive = Drive.fromJson(data);
     } else {
       final int id = _ride?.id ?? widget.id!;
       final Map<String, dynamic> data =
-          await SupabaseManager.supabaseClient.from('rides').select(_rideQuery).eq('id', id).single();
+          await supabaseManager.supabaseClient.from('rides').select(_rideQuery).eq('id', id).single();
       ride = Ride.fromJson(data);
     }
 
@@ -212,7 +212,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
       case RideStatus.withdrawnByRider:
         return Button(
           S.of(context).pageRideDetailButtonRequest,
-          onPressed: SupabaseManager.getCurrentProfile() == null ? _showLoginDialog : _showRequestDialog,
+          onPressed: supabaseManager.currentProfile == null ? _showLoginDialog : _showRequestDialog,
           key: const Key('requestRideButton'),
         );
       case RideStatus.approved:
@@ -312,7 +312,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   }
 
   Future<void> hideRide() async {
-    await SupabaseManager.supabaseClient
+    await supabaseManager.supabaseClient
         .from('rides')
         .update(<String, dynamic>{'hide_in_list_view': true}).eq('id', widget.ride!.id);
   }
@@ -348,7 +348,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
 
     // chat gets created by trigger, somehow it does not get returned immediately by the insert
     final Map<String, dynamic> idHash =
-        await SupabaseManager.supabaseClient.from('rides').insert(ride.toJson()).select().single();
+        await supabaseManager.supabaseClient.from('rides').insert(ride.toJson()).select().single();
 
     // TODO: Use copyWith and make id final again
     ride.id = idHash['id'] as int;

--- a/lib/rides/pages/rides_page.dart
+++ b/lib/rides/pages/rides_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/trip_page_builder.dart';
 import '../models/ride.dart';
 import 'search_ride_page.dart';
@@ -17,8 +17,8 @@ class _RidesPageState extends State<RidesPage> {
 
   @override
   void initState() {
-    final int userId = SupabaseManager.getCurrentProfile()!.id!;
-    _rides = SupabaseManager.supabaseClient
+    final int userId = supabaseManager.currentProfile!.id!;
+    _rides = supabaseManager.supabaseClient
         .from('rides')
         .stream(primaryKey: <String>['id'])
         .eq('rider_id', userId)

--- a/lib/rides/pages/search_ride_page.dart
+++ b/lib/rides/pages/search_ride_page.dart
@@ -9,7 +9,7 @@ import '../../util/locale_manager.dart';
 import '../../util/parse_helper.dart';
 import '../../util/search/address_suggestion.dart';
 import '../../util/search/start_destination_timeline.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import '../../util/trip/ride_card.dart';
 import '../../util/trip/trip.dart';
 import '../models/ride.dart';
@@ -109,7 +109,7 @@ class _SearchRidePageState extends State<SearchRidePage> {
     if (_startSuggestion == null || _destinationSuggestion == null) return;
     setState(() => _loading = true);
     final List<Map<String, dynamic>> data = parseHelper.parseListOfMaps(
-      await SupabaseManager.supabaseClient.from('drives').select('''
+      await supabaseManager.supabaseClient.from('drives').select('''
           *,
           driver:driver_id (
             *,
@@ -130,7 +130,7 @@ class _SearchRidePageState extends State<SearchRidePage> {
             _destinationSuggestion!.position,
             drive.endTime,
             _seats,
-            SupabaseManager.getCurrentProfile()?.id ?? -1,
+            supabaseManager.currentProfile?.id ?? -1,
             10.25,
           ),
         )

--- a/lib/util/chat/chat_bubble.dart
+++ b/lib/util/chat/chat_bubble.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../supabase.dart';
+import '../supabase_manager.dart';
 import 'models/message.dart';
 
 class ChatBubble extends StatelessWidget {
@@ -21,7 +21,7 @@ class ChatBubble extends StatelessWidget {
     Message message, {
     super.key,
     this.tail = true,
-  })  : isSender = message.senderId == SupabaseManager.getCurrentProfile()!.id,
+  })  : isSender = message.senderId == supabaseManager.currentProfile!.id,
         text = message.content,
         read = message.read;
 

--- a/lib/util/chat/message_bar.dart
+++ b/lib/util/chat/message_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import '../supabase.dart';
+import '../supabase_manager.dart';
 
 class MessageBar extends StatefulWidget {
   const MessageBar(this.chatId, {super.key});
@@ -70,8 +70,8 @@ class _MessageBarState extends State<MessageBar> {
       return;
     }
     _textController.clear();
-    await SupabaseManager.supabaseClient.from('messages').insert(<String, dynamic>{
-      'sender_id': SupabaseManager.getCurrentProfile()!.id,
+    await supabaseManager.supabaseClient.from('messages').insert(<String, dynamic>{
+      'sender_id': supabaseManager.currentProfile!.id,
       'content': text,
       'chat_id': widget.chatId,
     });

--- a/lib/util/chat/models/chat.dart
+++ b/lib/util/chat/models/chat.dart
@@ -1,7 +1,7 @@
 import '../../../rides/models/ride.dart';
 import '../../model.dart';
 import '../../parse_helper.dart';
-import '../../supabase.dart';
+import '../../supabase_manager.dart';
 import 'message.dart';
 
 class Chat extends Model {
@@ -33,7 +33,7 @@ class Chat extends Model {
 
   int getUnreadMessagesCount() {
     return messages!
-        .where((Message message) => message.senderId != SupabaseManager.getCurrentProfile()!.id && !message.read)
+        .where((Message message) => message.senderId != supabaseManager.currentProfile!.id && !message.read)
         .length;
   }
 

--- a/lib/util/chat/models/message.dart
+++ b/lib/util/chat/models/message.dart
@@ -1,6 +1,6 @@
 import '../../../account/models/profile.dart';
 import '../../model.dart';
-import '../../supabase.dart';
+import '../../supabase_manager.dart';
 import 'chat.dart';
 
 class Message extends Model {
@@ -53,12 +53,12 @@ class Message extends Model {
     };
   }
 
-  bool get isFromCurrentUser => senderId == SupabaseManager.getCurrentProfile()?.id;
+  bool get isFromCurrentUser => senderId == supabaseManager.currentProfile?.id;
 
   Future<void> markAsRead() async {
     read = true;
     //custom rpc call to mark message as read, so the user does not need the write permission on the messages table
-    await SupabaseManager.supabaseClient.rpc('mark_message_as_read', params: <String, dynamic>{'message_id': id});
+    await supabaseManager.supabaseClient.rpc('mark_message_as_read', params: <String, dynamic>{'message_id': id});
   }
 
   @override

--- a/lib/util/chat/pages/chat_page.dart
+++ b/lib/util/chat/pages/chat_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../account/models/profile.dart';
 import '../../profiles/profile_widget.dart';
-import '../../supabase.dart';
+import '../../supabase_manager.dart';
 import '../chat_bubble.dart';
 import '../message_bar.dart';
 import '../models/message.dart';
@@ -30,7 +30,7 @@ class _ChatPageState extends State<ChatPage> {
   @override
   void initState() {
     if (widget.active) {
-      _messagesStream = SupabaseManager.supabaseClient
+      _messagesStream = supabaseManager.supabaseClient
           .from('messages')
           .stream(primaryKey: <String>['id'])
           .eq('chat_id', widget.chatId)
@@ -119,7 +119,7 @@ class _ChatPageState extends State<ChatPage> {
   List<ChatBubble> _buildChatBubbles(List<Message> messages) {
     final List<ChatBubble> chatBubbles = <ChatBubble>[];
     for (int i = 0; i < messages.length; i++) {
-      if (!messages[i].read && messages[i].senderId != SupabaseManager.getCurrentProfile()!.id) {
+      if (!messages[i].read && messages[i].senderId != supabaseManager.currentProfile!.id) {
         messages[i].markAsRead();
       }
       chatBubbles.add(

--- a/lib/util/custom_timeline_theme.dart
+++ b/lib/util/custom_timeline_theme.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:timelines/timelines.dart';
 
+// We need to write this custom class to define our timeline theme and use the "of" method naturally.
+// ignore: avoid_classes_with_only_static_members
 class CustomTimelineTheme {
-  static TimelineThemeData of(BuildContext context) {
+  static TimelineThemeData of(BuildContext context, {bool forBuilder = false}) {
     return TimelineTheme.of(context).copyWith(
       nodePosition: 0,
       nodeItemOverlap: true,
@@ -10,17 +12,8 @@ class CustomTimelineTheme {
       indicatorTheme: IndicatorThemeData(
         color: Theme.of(context).colorScheme.onSurface,
         size: 15.0,
+        position: forBuilder ? 0.5 : null,
       ),
-    );
-  }
-}
-
-class CustomTimelineThemeForBuilder {
-  static TimelineThemeData of(BuildContext context) {
-    return CustomTimelineTheme.of(context).copyWith(
-      indicatorTheme: CustomTimelineTheme.of(context).indicatorTheme.copyWith(
-            position: 0.5,
-          ),
     );
   }
 }

--- a/lib/util/locale_manager.dart
+++ b/lib/util/locale_manager.dart
@@ -14,7 +14,7 @@ class LocaleManager with ChangeNotifier {
   late Locale currentLocale;
 
   Future<void> loadCurrentLocale() async {
-    await StorageManager.readData('locale').then((dynamic value) {
+    await storageManager.readData('locale').then((dynamic value) {
       value ??= Platform.localeName.split('_').first;
 
       final Locale locale =
@@ -28,7 +28,7 @@ class LocaleManager with ChangeNotifier {
     if (locale == null) return;
 
     currentLocale = locale;
-    StorageManager.saveData('locale', locale.languageCode);
+    storageManager.saveData('locale', locale.languageCode);
     notifyListeners();
   }
 

--- a/lib/util/search/address_suggestion_manager.dart
+++ b/lib/util/search/address_suggestion_manager.dart
@@ -7,7 +7,7 @@ import 'package:fuzzywuzzy/fuzzywuzzy.dart';
 import 'package:fuzzywuzzy/model/extracted_result.dart';
 
 import '../storage_manager.dart';
-import '../supabase.dart';
+import '../supabase_manager.dart';
 import 'address_suggestion.dart';
 
 final AddressSuggestionManager addressSuggestionManager = AddressSuggestionManager();
@@ -46,7 +46,7 @@ class AddressSuggestionManager {
   }
 
   Future<void> loadHistorySuggestions() async {
-    final List<String> data = await StorageManager.readStringList(getStorageKey());
+    final List<String> data = await storageManager.readStringList(getStorageKey());
 
     final Iterable<Map<String, dynamic>> suggestions = data.map((String suggestion) => jsonDecode(suggestion));
     _historySuggestions = suggestions
@@ -83,7 +83,7 @@ class AddressSuggestionManager {
     final List<String> data =
         _historySuggestions.map((AddressSuggestion suggestion) => jsonEncode(suggestion.toJson())).toList();
 
-    StorageManager.saveData(getStorageKey(), data);
+    storageManager.saveData(getStorageKey(), data);
   }
 
   void sortHistorySuggestions() {
@@ -194,6 +194,6 @@ class AddressSuggestionManager {
   }
 
   String getStorageKey() {
-    return '$_storageKey.${SupabaseManager.getCurrentProfile()?.id}';
+    return '$_storageKey.${supabaseManager.currentProfile?.id}';
   }
 }

--- a/lib/util/storage_manager.dart
+++ b/lib/util/storage_manager.dart
@@ -1,7 +1,9 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+StorageManager storageManager = StorageManager();
+
 class StorageManager {
-  static Future<void> saveData(String key, dynamic value) async {
+  Future<void> saveData(String key, dynamic value) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     if (value is int) {
       await prefs.setInt(key, value);
@@ -16,18 +18,18 @@ class StorageManager {
     }
   }
 
-  static Future<List<String>> readStringList(String key) async {
+  Future<List<String>> readStringList(String key) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     return prefs.getStringList(key) ?? <String>[];
   }
 
-  static Future<dynamic> readData(String key) async {
+  Future<dynamic> readData(String key) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final dynamic obj = prefs.get(key);
     return obj;
   }
 
-  static Future<bool> deleteData(String key) async {
+  Future<bool> deleteData(String key) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     return prefs.remove(key);
   }

--- a/lib/util/theme_manager.dart
+++ b/lib/util/theme_manager.dart
@@ -18,7 +18,7 @@ class ThemeManager with ChangeNotifier {
   late ThemeMode currentThemeMode;
 
   Future<void> loadTheme() async {
-    await StorageManager.readData('themeMode').then((dynamic value) {
+    await storageManager.readData('themeMode').then((dynamic value) {
       switch (value) {
         case 'system':
           currentThemeMode = ThemeMode.system;
@@ -40,7 +40,7 @@ class ThemeManager with ChangeNotifier {
     if (value == null) return;
 
     currentThemeMode = value;
-    StorageManager.saveData('themeMode', value.name);
+    storageManager.saveData('themeMode', value.name);
     notifyListeners();
   }
 }

--- a/lib/util/trip/drive_card.dart
+++ b/lib/util/trip/drive_card.dart
@@ -4,7 +4,7 @@ import '../../drives/models/drive.dart';
 import '../../drives/pages/drive_detail_page.dart';
 import '../../rides/models/ride.dart';
 import '../own_theme_fields.dart';
-import '../supabase.dart';
+import '../supabase_manager.dart';
 import 'seat_indicator.dart';
 import 'trip_card.dart';
 
@@ -39,7 +39,7 @@ class _DriveCardState extends TripCardState<Drive, DriveCard> {
   }
 
   Future<void> loadDrive() async {
-    final Map<String, dynamic> data = await SupabaseManager.supabaseClient.from('drives').select('''
+    final Map<String, dynamic> data = await supabaseManager.supabaseClient.from('drives').select('''
       *,
       rides(
         *,

--- a/lib/util/trip/pending_ride_card.dart
+++ b/lib/util/trip/pending_ride_card.dart
@@ -7,7 +7,7 @@ import '../icon_widget.dart';
 import '../locale_manager.dart';
 import '../profiles/profile_widget.dart';
 import '../snackbar.dart';
-import '../supabase.dart';
+import '../supabase_manager.dart';
 import 'trip_card.dart';
 
 class PendingRideCard extends TripCard<Ride> {
@@ -90,7 +90,7 @@ class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
   Future<void> approveRide() async {
     //custom rpc call to mark the ride as approved,
     //so the user does not need the write permission on the rides table.
-    await SupabaseManager.supabaseClient.rpc(
+    await supabaseManager.supabaseClient.rpc(
       'approve_ride',
       params: <String, dynamic>{'ride_id': _ride.id},
     );
@@ -101,7 +101,7 @@ class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
   Future<void> rejectRide() async {
     //custom rpc call to mark the ride as rejected,
     //so the user does not need the write permission on the rides table.
-    await SupabaseManager.supabaseClient.rpc(
+    await supabaseManager.supabaseClient.rpc(
       'reject_ride',
       params: <String, dynamic>{'ride_id': _ride.id},
     );

--- a/lib/util/trip/ride_card.dart
+++ b/lib/util/trip/ride_card.dart
@@ -12,7 +12,7 @@ import '../own_theme_fields.dart';
 import '../profiles/profile_widget.dart';
 import '../profiles/reviews/custom_rating_bar_indicator.dart';
 import '../profiles/reviews/custom_rating_bar_size.dart';
-import '../supabase.dart';
+import '../supabase_manager.dart';
 import 'trip_card.dart';
 
 class RideCard extends TripCard<Ride> {
@@ -66,7 +66,7 @@ class _RideCardState extends TripCardState<Ride, RideCard> {
   Future<void> loadRide() async {
     Ride trip = widget.trip;
     final Map<String, dynamic> data =
-        await SupabaseManager.supabaseClient.from('drives').select(_driveQuery).eq('id', trip.driveId).single();
+        await supabaseManager.supabaseClient.from('drives').select(_driveQuery).eq('id', trip.driveId).single();
     trip.drive = Drive.fromJson(data);
     if (mounted) {
       setState(() {

--- a/lib/welcome/pages/forgot_password_page.dart
+++ b/lib/welcome/pages/forgot_password_page.dart
@@ -5,7 +5,7 @@ import 'package:progress_state_button/progress_button.dart';
 
 import '../../util/buttons/loading_button.dart';
 import '../../util/fields/email_field.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
   final String? initialEmail;
@@ -62,7 +62,7 @@ class ForgotPasswordFormState extends State<ForgotPasswordForm> {
       buttonState = ButtonState.loading;
     });
 
-    await SupabaseManager.supabaseClient.auth.resetPasswordForEmail(
+    await supabaseManager.supabaseClient.auth.resetPasswordForEmail(
       emailController.text,
       redirectTo: kIsWeb ? null : 'io.supabase.flutter://reset-callback/',
     );

--- a/lib/welcome/pages/login_page.dart
+++ b/lib/welcome/pages/login_page.dart
@@ -9,7 +9,7 @@ import '../../util/buttons/loading_button.dart';
 import '../../util/fields/email_field.dart';
 import '../../util/fields/password_field.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import 'forgot_password_page.dart';
 import 'register_page.dart';
 
@@ -66,7 +66,7 @@ class LoginFormState extends State<LoginForm> {
     });
 
     try {
-      await SupabaseManager.supabaseClient.auth.signInWithPassword(
+      await supabaseManager.supabaseClient.auth.signInWithPassword(
         email: emailController.text,
         password: passwordController.text,
       );

--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -10,7 +10,7 @@ import '../../util/buttons/loading_button.dart';
 import '../../util/fields/email_field.dart';
 import '../../util/fields/password_field.dart';
 import '../../util/snackbar.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 import 'after_registration_page.dart';
 
 class RegisterPage extends StatefulWidget {
@@ -62,7 +62,7 @@ class RegisterFormState extends State<RegisterForm> {
       setState(() {
         buttonState = ButtonState.loading;
       });
-      res = await SupabaseManager.supabaseClient.auth.signUp(
+      res = await supabaseManager.supabaseClient.auth.signUp(
         password: passwordController.text,
         email: emailController.text,
         emailRedirectTo: 'io.supabase.flutter://login-callback/',
@@ -78,7 +78,7 @@ class RegisterFormState extends State<RegisterForm> {
     }
 
     try {
-      await SupabaseManager.supabaseClient.from('profiles').insert(<String, dynamic>{
+      await supabaseManager.supabaseClient.from('profiles').insert(<String, dynamic>{
         'auth_id': user.id,
         'email': user.email,
         'username': usernameController.text,

--- a/lib/welcome/pages/reset_password_page.dart
+++ b/lib/welcome/pages/reset_password_page.dart
@@ -5,7 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../util/buttons/loading_button.dart';
 import '../../util/fields/password_field.dart';
-import '../../util/supabase.dart';
+import '../../util/supabase_manager.dart';
 
 class ResetPasswordPage extends StatefulWidget {
   final Function() onPasswordReset;
@@ -58,7 +58,7 @@ class ResetPasswordFormState extends State<ResetPasswordForm> {
     });
 
     final UserAttributes newAttributes = UserAttributes(password: passwordController.text);
-    await SupabaseManager.supabaseClient.auth.updateUser(newAttributes);
+    await supabaseManager.supabaseClient.auth.updateUser(newAttributes);
 
     // Will redirect to login screen if successful
     widget.onPasswordReset();

--- a/test/models/chat_test.dart
+++ b/test/models/chat_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
 import 'package:motis_mitfahr_app/util/chat/models/chat.dart';
 import 'package:motis_mitfahr_app/util/chat/models/message.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 
 import '../util/factories/chat_factory.dart';
 import '../util/factories/message_factory.dart';
@@ -33,7 +33,8 @@ void main() {
       senderId: profileId + 1,
       createDependencies: false,
     );
-    SupabaseManager.setCurrentProfile(profile);
+    supabaseManager.currentProfile = profile;
+
     test('zero when Messages are empty', () async {
       final chat = ChatFactory().generateFake(
         messages: NullableParameter([]),

--- a/test/models/message_test.dart
+++ b/test/models/message_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
 import 'package:motis_mitfahr_app/util/chat/models/chat.dart';
 import 'package:motis_mitfahr_app/util/chat/models/message.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 
 import '../util/factories/chat_factory.dart';
 import '../util/factories/message_factory.dart';
@@ -42,23 +42,23 @@ void main() {
   group('Message.isFromCurrentUser', () {
     setUp(() {
       final profile = ProfileFactory().generateFake();
-      SupabaseManager.setCurrentProfile(profile);
+      supabaseManager.currentProfile = profile;
     });
     test('returns true if message is from current user', () async {
       final message = MessageFactory().generateFake(
-        senderId: SupabaseManager.getCurrentProfile()?.id,
+        senderId: supabaseManager.currentProfile!.id,
       );
       expect(message.isFromCurrentUser, true);
     });
     test('returns false if message is not from current user', () async {
       final message = MessageFactory().generateFake(
-        senderId: SupabaseManager.getCurrentProfile()!.id! + 1,
+        senderId: supabaseManager.currentProfile!.id! + 1,
       );
       expect(message.isFromCurrentUser, false);
     });
 
     test('returns false if current user is null', () async {
-      SupabaseManager.setCurrentProfile(null);
+      supabaseManager.currentProfile = null;
       final message = MessageFactory().generateFake();
       expect(message.isFromCurrentUser, false);
     });

--- a/test/models/profile_test.dart
+++ b/test/models/profile_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 
 import '../util/factories/model_factory.dart';
 import '../util/factories/profile_factory.dart';
@@ -47,14 +47,14 @@ void main() {
       final currentProfile = ProfileFactory().generateFake(
         id: profile.id,
       );
-      SupabaseManager.setCurrentProfile(currentProfile);
+      supabaseManager.currentProfile = currentProfile;
       expect(profile.isCurrentUser, true);
     });
 
     test('returns false if id is not equal to current profile id', () async {
       final profile = ProfileFactory().generateFake();
       final currentProfile = ProfileFactory().generateFake(id: profile.id! + 1);
-      SupabaseManager.setCurrentProfile(currentProfile);
+      supabaseManager.currentProfile = currentProfile;
       expect(profile.isCurrentUser, false);
     });
   });

--- a/test/util/mocks/mock_server.dart
+++ b/test/util/mocks/mock_server.dart
@@ -3,42 +3,42 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'request_processor.dart';
 
+// I think this reads better with a static class, but maybe change in the future
+// ignore: avoid_classes_with_only_static_members
 class MockServer {
   static void setProcessor(RequestProcessor processor) {
-    SupabaseManager.setClient(
-      SupabaseClient(
-        '',
-        '',
-        httpClient: MockClient(
-          (request) {
-            // Uncomment this to see the requests
-            // print('Request: ${request.url}');
-            // print('Body: ${request.body}');
-            // print('Method: ${request.method}');
+    supabaseManager.supabaseClient = SupabaseClient(
+      '',
+      '',
+      httpClient: MockClient(
+        (request) {
+          // Uncomment this to see the requests
+          // print('Request: ${request.url}');
+          // print('Body: ${request.body}');
+          // print('Method: ${request.method}');
 
-            final ProcessorResult result = processor.process(
-              request.url.toString(),
-              method: request.method,
-              body: request.body.isEmpty ? null : jsonDecode(request.body),
-            );
+          final ProcessorResult result = processor.process(
+            request.url.toString(),
+            method: request.method,
+            body: request.body.isEmpty ? null : jsonDecode(request.body),
+          );
 
-            return Future.value(
-              Response(
-                result.body,
-                result.statusCode,
-                headers: {
-                  'content-type': 'application/json',
-                },
-                request: request,
-              ),
-            );
-          },
-        ),
+          return Future.value(
+            Response(
+              result.body,
+              result.statusCode,
+              headers: {
+                'content-type': 'application/json',
+              },
+              request: request,
+            ),
+          );
+        },
       ),
     );
   }

--- a/test/widgets/chat/chat_page_test.dart
+++ b/test/widgets/chat/chat_page_test.dart
@@ -5,7 +5,7 @@ import 'package:motis_mitfahr_app/util/chat/chat_bubble.dart';
 import 'package:motis_mitfahr_app/util/chat/message_bar.dart';
 import 'package:motis_mitfahr_app/util/chat/pages/chat_page.dart';
 import 'package:motis_mitfahr_app/util/profiles/profile_widget.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../util/factories/message_factory.dart';
@@ -32,7 +32,7 @@ void main() {
       processor,
       urlMatcher: equals('/rest/v1/messages?select=%2A&chat_id=eq.$chatId&order=created_at.desc.nullslast'),
     ).called(1);
-    final List<RealtimeChannel> subscription = SupabaseManager.supabaseClient.getChannels();
+    final List<RealtimeChannel> subscription = supabaseManager.supabaseClient.getChannels();
     expect(subscription.length, 1);
     expect(subscription[0].topic, 'realtime:public:messages:1');
   });
@@ -70,7 +70,7 @@ void main() {
       const String message = 'Hello World';
 
       Future<void> setUpMessageBar(WidgetTester tester) async {
-        SupabaseManager.setCurrentProfile(profile);
+        supabaseManager.currentProfile = profile;
         await pumpMaterial(tester, ChatPage(profile: profile, chatId: chatId));
         await tester.pump();
 
@@ -137,7 +137,7 @@ void main() {
       whenRequest(processor).thenReturnJson([
         MessageFactory().generateFake(senderId: profile.id).toJsonForApi(),
       ]);
-      SupabaseManager.setCurrentProfile(profile);
+      supabaseManager.currentProfile = profile;
       await pumpMaterial(tester, ChatPage(profile: profile, chatId: chatId));
       await tester.pump();
 
@@ -160,7 +160,7 @@ void main() {
 
     testWidgets('shows tail exactly when it should be shown', (WidgetTester tester) async {
       final Profile currentProfile = ProfileFactory().generateFake();
-      SupabaseManager.setCurrentProfile(currentProfile);
+      supabaseManager.currentProfile = currentProfile;
       final List<Map<String, dynamic>> messages = [
         MessageFactory()
             .generateFake(

--- a/test/widgets/chat/drive_chat_page_test.dart
+++ b/test/widgets/chat/drive_chat_page_test.dart
@@ -7,7 +7,7 @@ import 'package:motis_mitfahr_app/drives/pages/drive_chat_page.dart';
 import 'package:motis_mitfahr_app/rides/models/ride.dart';
 import 'package:motis_mitfahr_app/util/chat/models/message.dart';
 import 'package:motis_mitfahr_app/util/chat/pages/chat_page.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../util/factories/chat_factory.dart';
@@ -50,7 +50,7 @@ void main() {
         processor,
         urlMatcher: equals('/rest/v1/messages?select=%2A&order=created_at.desc.nullslast'),
       ).called(1);
-      final List<RealtimeChannel> subscription = SupabaseManager.supabaseClient.getChannels();
+      final List<RealtimeChannel> subscription = supabaseManager.supabaseClient.getChannels();
       expect(subscription.length, 1);
       expect(subscription[0].topic, 'realtime:public:messages:1');
     });
@@ -67,7 +67,7 @@ void main() {
         processor,
         urlMatcher: equals('/rest/v1/messages?select=%2A&order=created_at.desc.nullslast'),
       );
-      final List<RealtimeChannel> subscription = SupabaseManager.supabaseClient.getChannels();
+      final List<RealtimeChannel> subscription = supabaseManager.supabaseClient.getChannels();
       expect(subscription.length, 0);
     });
 
@@ -87,7 +87,7 @@ void main() {
         processor,
         urlMatcher: equals('/rest/v1/messages?select=%2A&order=created_at.desc.nullslast'),
       );
-      final List<RealtimeChannel> subscription = SupabaseManager.supabaseClient.getChannels();
+      final List<RealtimeChannel> subscription = supabaseManager.supabaseClient.getChannels();
       expect(subscription.length, 0);
     });
   });
@@ -208,7 +208,7 @@ void main() {
     });
     group('Icon.done_all', () {
       setUp(() {
-        SupabaseManager.setCurrentProfile(profile);
+        supabaseManager.currentProfile = profile;
       });
       testWidgets('is shown when last Message is from current user', (WidgetTester tester) async {
         final Message message = MessageFactory().generateFake(
@@ -263,7 +263,7 @@ void main() {
     });
     group('shows unreadMessage count', () {
       setUp(() {
-        SupabaseManager.setCurrentProfile(profile);
+        supabaseManager.currentProfile = profile;
       });
 
       testWidgets('when there are unread Messages', (WidgetTester tester) async {

--- a/test/widgets/drives_page_test.dart
+++ b/test/widgets/drives_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
 import 'package:motis_mitfahr_app/drives/pages/create_drive_page.dart';
 import 'package:motis_mitfahr_app/drives/pages/drives_page.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../util/factories/profile_factory.dart';
@@ -21,12 +21,12 @@ void main() {
   });
   setUp(() async {
     profile = ProfileFactory().generateFake(id: 1);
-    SupabaseManager.setCurrentProfile(profile);
+    supabaseManager.currentProfile = profile;
     whenRequest(processor).thenReturnJson([]);
   });
   testWidgets('has stream subscription', (WidgetTester tester) async {
     await pumpMaterial(tester, const DrivesPage());
-    final List<RealtimeChannel> subscription = SupabaseManager.supabaseClient.getChannels();
+    final List<RealtimeChannel> subscription = supabaseManager.supabaseClient.getChannels();
     expect(subscription.length, 1);
     expect(subscription[0].topic, 'realtime:public:drives:1');
     verifyRequest(

--- a/test/widgets/flutter_test_config.dart
+++ b/test/widgets/flutter_test_config.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/util/locale_manager.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/util/theme_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -12,7 +12,7 @@ import '../util/factories/profile_factory.dart';
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
-    SupabaseManager.setCurrentProfile(ProfileFactory().generateFake());
+    supabaseManager.currentProfile = ProfileFactory().generateFake();
     localeManager.currentLocale = const Locale('en');
     themeManager.setTheme(ThemeMode.light);
   });

--- a/test/widgets/main_test.dart
+++ b/test/widgets/main_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/main.dart';
 import 'package:motis_mitfahr_app/main_app.dart';
 import 'package:motis_mitfahr_app/util/locale_manager.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/util/theme_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/reset_password_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/welcome_page.dart';
@@ -81,13 +81,13 @@ void main() {
         bodyMatcher: equals({'refresh_token': 'my_refresh_token'}),
         methodMatcher: equals('POST'),
       ).thenReturnJson(responseHash);
-      await SupabaseManager.supabaseClient.auth.setSession('my_refresh_token');
-      await SupabaseManager.reloadCurrentProfile();
+      await supabaseManager.supabaseClient.auth.setSession('my_refresh_token');
+      await supabaseManager.reloadCurrentProfile();
     }
 
     setUp(() {
-      SupabaseManager.setCurrentProfile(null);
-      SupabaseManager.supabaseClient.auth.signOut();
+      supabaseManager.currentProfile = null;
+      supabaseManager.supabaseClient.auth.signOut();
     });
 
     testWidgets('It shows Welcome when not logged in', (WidgetTester tester) async {
@@ -117,7 +117,7 @@ void main() {
       ).thenReturnJson(responseHash);
 
       // Sending AuthChangeEvent.signedIn
-      await SupabaseManager.supabaseClient.auth.signInWithPassword(
+      await supabaseManager.supabaseClient.auth.signInWithPassword(
         email: 'motismitfahrapp@gmail.com',
         password: '?Pass123word',
       );
@@ -135,7 +135,7 @@ void main() {
       expect(find.byType(MainApp), findsOneWidget);
 
       // Sending AuthChangeEvent.signedOut
-      await SupabaseManager.supabaseClient.auth.signOut();
+      await supabaseManager.supabaseClient.auth.signOut();
 
       await tester.pump();
 
@@ -151,7 +151,7 @@ void main() {
         methodMatcher: equals('GET'),
       ).thenReturnJson(userHash);
 
-      await SupabaseManager.supabaseClient.auth.getSessionFromUrl(
+      await supabaseManager.supabaseClient.auth.getSessionFromUrl(
         Uri(host: 'localhost', port: 3000, queryParameters: {
           'access_token': 'access_token',
           'expires_in': '3600',

--- a/test/widgets/ride_detail_page_test.dart
+++ b/test/widgets/ride_detail_page_test.dart
@@ -13,7 +13,7 @@ import 'package:motis_mitfahr_app/util/chat/pages/chat_page.dart';
 import 'package:motis_mitfahr_app/util/profiles/profile_chip.dart';
 import 'package:motis_mitfahr_app/util/profiles/profile_widget.dart';
 import 'package:motis_mitfahr_app/util/profiles/profile_wrap_list.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/util/trip/trip_overview.dart';
 import 'package:motis_mitfahr_app/welcome/pages/login_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/register_page.dart';
@@ -420,7 +420,7 @@ void main() {
       group('Login Dialog', () {
         setUp(() {
           ride.chat = null;
-          SupabaseManager.setCurrentProfile(null);
+          supabaseManager.currentProfile = null;
         });
 
         testWidgets('Can cancel', (WidgetTester tester) async {

--- a/test/widgets/rides_page_test.dart
+++ b/test/widgets/rides_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/account/models/profile.dart';
 import 'package:motis_mitfahr_app/rides/pages/rides_page.dart';
 import 'package:motis_mitfahr_app/rides/pages/search_ride_page.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../util/factories/profile_factory.dart';
@@ -21,12 +21,12 @@ void main() {
   });
   setUp(() async {
     profile = ProfileFactory().generateFake(id: 1);
-    SupabaseManager.setCurrentProfile(profile);
+    supabaseManager.currentProfile = profile;
     whenRequest(processor).thenReturnJson([]);
   });
   testWidgets('has stream subscription', (WidgetTester tester) async {
     await pumpMaterial(tester, const RidesPage());
-    final List<RealtimeChannel> subscription = SupabaseManager.supabaseClient.getChannels();
+    final List<RealtimeChannel> subscription = supabaseManager.supabaseClient.getChannels();
     expect(subscription.length, 1);
     expect(subscription[0].topic, 'realtime:public:rides:1');
     verifyRequest(

--- a/test/widgets/trip_page_builder_test.dart
+++ b/test/widgets/trip_page_builder_test.dart
@@ -5,7 +5,7 @@ import 'package:motis_mitfahr_app/account/models/profile.dart';
 import 'package:motis_mitfahr_app/drives/pages/drives_page.dart';
 import 'package:motis_mitfahr_app/rides/models/ride.dart';
 import 'package:motis_mitfahr_app/rides/pages/rides_page.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/util/trip/drive_card.dart';
 import 'package:motis_mitfahr_app/util/trip/ride_card.dart';
 
@@ -30,7 +30,7 @@ void main() {
   setUp(() async {
     reset(processor);
     profile = ProfileFactory().generateFake(id: 1);
-    SupabaseManager.setCurrentProfile(profile);
+    supabaseManager.currentProfile = profile;
   });
 
   // since the code for the TripPageBuilder is the same for both pages,

--- a/test/widgets/welcome/after_registration_page_test.dart
+++ b/test/widgets/welcome/after_registration_page_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/after_registration_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/login_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/welcome_page.dart';
@@ -9,7 +9,7 @@ import '../../util/pump_material.dart';
 
 void main() {
   setUpAll(() async {
-    SupabaseManager.setCurrentProfile(null);
+    supabaseManager.currentProfile = null;
   });
 
   group('WelcomePage', () {

--- a/test/widgets/welcome/forgot_password_page_test.dart
+++ b/test/widgets/welcome/forgot_password_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:motis_mitfahr_app/util/buttons/loading_button.dart';
 import 'package:motis_mitfahr_app/util/fields/email_field.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/forgot_password_page.dart';
 import 'package:progress_state_button/progress_button.dart';
 
@@ -20,7 +20,7 @@ void main() {
 
   setUpAll(() async {
     MockServer.setProcessor(processor);
-    SupabaseManager.setCurrentProfile(null);
+    supabaseManager.currentProfile = null;
   });
 
   group('ForgotPasswordPage', () {

--- a/test/widgets/welcome/login_page_test.dart
+++ b/test/widgets/welcome/login_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/util/buttons/loading_button.dart';
 import 'package:motis_mitfahr_app/util/fields/email_field.dart';
 import 'package:motis_mitfahr_app/util/fields/password_field.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/forgot_password_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/login_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/register_page.dart';
@@ -21,7 +21,7 @@ void main() {
 
   setUpAll(() async {
     MockServer.setProcessor(processor);
-    SupabaseManager.setCurrentProfile(null);
+    supabaseManager.currentProfile = null;
   });
 
   group('LoginPage', () {

--- a/test/widgets/welcome/register_page_test.dart
+++ b/test/widgets/welcome/register_page_test.dart
@@ -4,7 +4,7 @@ import 'package:motis_mitfahr_app/account/models/profile.dart';
 import 'package:motis_mitfahr_app/util/buttons/loading_button.dart';
 import 'package:motis_mitfahr_app/util/fields/email_field.dart';
 import 'package:motis_mitfahr_app/util/fields/password_field.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/after_registration_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/register_page.dart';
 import 'package:progress_state_button/progress_button.dart';
@@ -22,7 +22,7 @@ void main() {
 
   setUpAll(() async {
     MockServer.setProcessor(processor);
-    SupabaseManager.setCurrentProfile(null);
+    supabaseManager.currentProfile = null;
   });
 
   group('RegisterPage', () {

--- a/test/widgets/welcome/reset_password_page_test.dart
+++ b/test/widgets/welcome/reset_password_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:motis_mitfahr_app/util/buttons/loading_button.dart';
 import 'package:motis_mitfahr_app/util/fields/password_field.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/reset_password_page.dart';
 import 'package:progress_state_button/progress_button.dart';
 
@@ -36,7 +36,7 @@ void main() {
       urlMatcher: equals('/auth/v1/user?'),
       methodMatcher: equals('GET'),
     ).thenReturnJson(userHash);
-    SupabaseManager.supabaseClient.auth.getSessionFromUrl(
+    supabaseManager.supabaseClient.auth.getSessionFromUrl(
       Uri(host: 'localhost', port: 3000, queryParameters: {
         'access_token': 'access_token',
         'expires_in': '3600',

--- a/test/widgets/welcome/welcome_page_test.dart
+++ b/test/widgets/welcome/welcome_page_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:motis_mitfahr_app/rides/pages/search_ride_page.dart';
-import 'package:motis_mitfahr_app/util/supabase.dart';
+import 'package:motis_mitfahr_app/util/supabase_manager.dart';
 import 'package:motis_mitfahr_app/welcome/pages/login_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/register_page.dart';
 import 'package:motis_mitfahr_app/welcome/pages/welcome_page.dart';
@@ -10,7 +10,7 @@ import '../../util/pump_material.dart';
 
 void main() {
   setUpAll(() async {
-    SupabaseManager.setCurrentProfile(null);
+    supabaseManager.currentProfile = null;
   });
 
   group('WelcomePage', () {


### PR DESCRIPTION
- `avoid_classes_with_only_static_members`: I converted StorageManager & SupabaseManager to default instance exports
- `use_setters_to_change_properties`. Just changed the assignment for SupabaseManager setClient and setCurrentProfile. Now please use `supabaseManager.currentProfile = ... ` and `supabaseManager.client = ... `. Same for the getters, of course.

I also had to move some code into the initialize method to make sure that "Supabase.instance.client" is not called inside the tests, where it would not have been initialized.

Finally, I renamed the file to include the "Manager" name