### PR TITLE
Enable very strict type checks

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,8 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/lib/account/models/profile.dart
+++ b/lib/account/models/profile.dart
@@ -57,16 +57,16 @@ class Profile extends Model {
   @override
   factory Profile.fromJson(Map<String, dynamic> json) {
     return Profile(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      username: json['username'],
-      email: json['email'],
-      description: json['description'],
-      birthDate: json['birth_date'] != null ? DateTime.parse(json['birth_date']) : null,
-      surname: json['surname'],
-      name: json['name'],
-      gender: json['gender'] != null ? Gender.values[json['gender']] : null,
-      avatarUrl: json['avatar_url'],
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      username: json['username'] as String,
+      email: json['email'] as String,
+      description: json['description'] as String?,
+      birthDate: json['birth_date'] != null ? DateTime.parse(json['birth_date'] as String) : null,
+      surname: json['surname'] as String?,
+      name: json['name'] as String?,
+      gender: json['gender'] != null ? Gender.values[json['gender'] as int] : null,
+      avatarUrl: json['avatar_url'] as String?,
       reviewsReceived: json.containsKey('reviews_received')
           ? Review.fromJsonList(parseHelper.parseListOfMaps(json['reviews_received']))
           : null,

--- a/lib/account/models/profile_feature.dart
+++ b/lib/account/models/profile_feature.dart
@@ -24,12 +24,12 @@ class ProfileFeature extends Model {
   @override
   factory ProfileFeature.fromJson(Map<String, dynamic> json) {
     return ProfileFeature(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      profileId: json['profile_id'],
-      profile: json['profile'] != null ? Profile.fromJson(json['profile']) : null,
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      profileId: json['profile_id'] as int,
+      profile: json['profile'] != null ? Profile.fromJson(json['profile'] as Map<String, dynamic>) : null,
       feature: Feature.values.elementAt(json['feature'] as int),
-      rank: json['rank'],
+      rank: json['rank'] as int,
     );
   }
 

--- a/lib/account/models/report.dart
+++ b/lib/account/models/report.dart
@@ -30,14 +30,14 @@ class Report extends Model {
   @override
   factory Report.fromJson(Map<String, dynamic> json) {
     return Report(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      offenderId: json['offender_id'],
-      offender: json['offender'] != null ? Profile.fromJson(json['offender']) : null,
-      reporterId: json['reporter_id'],
-      reporter: json['reporter'] != null ? Profile.fromJson(json['reporter']) : null,
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      offenderId: json['offender_id'] as int,
+      offender: json['offender'] != null ? Profile.fromJson(json['offender'] as Map<String, dynamic>) : null,
+      reporterId: json['reporter_id'] as int,
+      reporter: json['reporter'] != null ? Profile.fromJson(json['reporter'] as Map<String, dynamic>) : null,
       category: ReportCategory.values.elementAt(json['category'] as int),
-      text: json['text'],
+      text: json['text'] as String?,
     );
   }
 

--- a/lib/account/models/review.dart
+++ b/lib/account/models/review.dart
@@ -35,18 +35,18 @@ class Review extends Model implements Comparable<Review> {
   @override
   factory Review.fromJson(Map<String, dynamic> json) {
     return Review(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      rating: json['rating'],
-      comfortRating: json['comfort_rating'],
-      safetyRating: json['safety_rating'],
-      reliabilityRating: json['reliability_rating'],
-      hospitalityRating: json['hospitality_rating'],
-      text: json['text'],
-      writerId: json['writer_id'],
-      writer: json.containsKey('writer') ? Profile.fromJson(json['writer']) : null,
-      receiverId: json['receiver_id'],
-      receiver: json.containsKey('receiver') ? Profile.fromJson(json['receiver']) : null,
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      rating: json['rating'] as int,
+      comfortRating: json['comfort_rating'] as int?,
+      safetyRating: json['safety_rating'] as int?,
+      reliabilityRating: json['reliability_rating'] as int?,
+      hospitalityRating: json['hospitality_rating'] as int?,
+      text: json['text'] as String?,
+      writerId: json['writer_id'] as int,
+      writer: json.containsKey('writer') ? Profile.fromJson(json['writer'] as Map<String, dynamic>) : null,
+      receiverId: json['receiver_id'] as int,
+      receiver: json.containsKey('receiver') ? Profile.fromJson(json['receiver'] as Map<String, dynamic>) : null,
     );
   }
 

--- a/lib/account/pages/account_page.dart
+++ b/lib/account/pages/account_page.dart
@@ -89,10 +89,10 @@ class _AccountPageState extends State<AccountPage> {
   void refresh() => setState(() {});
 
   void showDesignDialog(BuildContext context) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => StatefulBuilder(
-        builder: (BuildContext context, Function(VoidCallback) innerSetState) => AlertDialog(
+        builder: (BuildContext context, void Function(VoidCallback) innerSetState) => AlertDialog(
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: List<RadioListTile<ThemeMode>>.generate(
@@ -124,10 +124,10 @@ class _AccountPageState extends State<AccountPage> {
   }
 
   void showLanguageDialog(BuildContext context) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => StatefulBuilder(
-        builder: (BuildContext context, Function(VoidCallback) innerSetState) => AlertDialog(
+        builder: (BuildContext context, void Function(VoidCallback) innerSetState) => AlertDialog(
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: List<RadioListTile<Locale>>.generate(

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -46,7 +46,8 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> loadProfile() async {
-    final Map<String, dynamic> data = await supabaseManager.supabaseClient.from('profiles').select('''
+    final Map<String, dynamic> data =
+        await supabaseManager.supabaseClient.from('profiles').select<Map<String, dynamic>>('''
       *,
       profile_features (*),
       reviews_received: reviews!reviews_receiver_id_fkey(

--- a/lib/account/pages/reviews_page.dart
+++ b/lib/account/pages/reviews_page.dart
@@ -42,14 +42,15 @@ class _ReviewsPageState extends State<ReviewsPage> {
   }
 
   Future<void> load() async {
-    final Map<String, dynamic> profileData = await supabaseManager.supabaseClient.from('profiles').select('''
+    final Map<String, dynamic> profileData =
+        await supabaseManager.supabaseClient.from('profiles').select<Map<String, dynamic>>('''
       *,
       reviews_received: reviews!reviews_receiver_id_fkey(
         *,
         writer: writer_id(*)
       )''').eq('id', _profileId).single();
     final List<Map<String, dynamic>> commonRidesData = parseHelper.parseListOfMaps(
-      await supabaseManager.supabaseClient.from('rides').select('''
+      await supabaseManager.supabaseClient.from('rides').select<Map<String, dynamic>>('''
           *,
           drive: drives!inner(*)
         ''').eq('rider_id', supabaseManager.currentProfile!.id).eq('drive.driver_id', _profileId),

--- a/lib/account/pages/write_review_page.dart
+++ b/lib/account/pages/write_review_page.dart
@@ -41,7 +41,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
   Future<void> loadReview() async {
     final Map<String, dynamic>? data = await supabaseManager.supabaseClient
         .from('reviews')
-        .select('*')
+        .select<Map<String, dynamic>?>()
         .eq('receiver_id', widget.profile.id)
         .eq('writer_id', supabaseManager.currentProfile!.id)
         .limit(1)
@@ -136,7 +136,7 @@ class _WriteReviewPageState extends State<WriteReviewPage> {
     );
   }
 
-  Widget _buildCategoryReviewRow(String category, int? rating, Function(double) onRatingUpdate) {
+  Widget _buildCategoryReviewRow(String category, int? rating, void Function(double) onRatingUpdate) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[

--- a/lib/account/widgets/editable_row.dart
+++ b/lib/account/widgets/editable_row.dart
@@ -5,7 +5,7 @@ class EditableRow extends StatelessWidget {
   final String title;
   final Widget innerWidget;
   final bool isEditable;
-  final Function() onPressed;
+  final VoidCallback onPressed;
 
   const EditableRow({
     super.key,

--- a/lib/drives/models/drive.dart
+++ b/lib/drives/models/drive.dart
@@ -35,19 +35,19 @@ class Drive extends Trip {
   @override
   factory Drive.fromJson(Map<String, dynamic> json) {
     return Drive(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      start: json['start'],
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      start: json['start'] as String,
       startPosition: Position.fromDynamicValues(json['start_lat'], json['start_lng']),
-      startTime: DateTime.parse(json['start_time']),
-      end: json['end'],
+      startTime: DateTime.parse(json['start_time'] as String),
+      end: json['end'] as String,
       endPosition: Position.fromDynamicValues(json['end_lat'], json['end_lng']),
-      endTime: DateTime.parse(json['end_time']),
-      seats: json['seats'],
-      cancelled: json['cancelled'],
-      hideInListView: json['hide_in_list_view'],
-      driverId: json['driver_id'],
-      driver: json.containsKey('driver') ? Profile.fromJson(json['driver']) : null,
+      endTime: DateTime.parse(json['end_time'] as String),
+      seats: json['seats'] as int,
+      cancelled: json['cancelled'] as bool,
+      hideInListView: json['hide_in_list_view'] as bool,
+      driverId: json['driver_id'] as int,
+      driver: json.containsKey('driver') ? Profile.fromJson(json['driver'] as Map<String, dynamic>) : null,
       rides: json.containsKey('rides') ? Ride.fromJsonList(parseHelper.parseListOfMaps(json['rides'])) : null,
     );
   }
@@ -79,9 +79,10 @@ class Drive extends Trip {
   List<Ride>? get ridesWithChat => rides?.where((Ride ride) => ride.status.activeChat()).toList();
 
   static Future<bool> userHasDriveAtTimeRange(DateTimeRange range, int userId) async {
-    final List<Map<String, dynamic>> data = parseHelper.parseListOfMaps(
-      await supabaseManager.supabaseClient.from('drives').select().eq('driver_id', userId),
-    );
+    final List<Map<String, dynamic>> data = await supabaseManager.supabaseClient
+        .from('drives')
+        .select<List<Map<String, dynamic>>>()
+        .eq('driver_id', userId);
     List<Drive> drives = Drive.fromJsonList(data);
     drives = drives.where((Drive drive) => !drive.cancelled && !drive.isFinished).toList();
 

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -48,7 +48,8 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   Future<void> loadDrive() async {
-    final Map<String, dynamic> data = await supabaseManager.supabaseClient.from('drives').select('''
+    final Map<String, dynamic> data =
+        await supabaseManager.supabaseClient.from('drives').select<Map<String, dynamic>>('''
       *,
       rides(
         *,
@@ -401,7 +402,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   void _showHideDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageDriveDetailButtonHide),
@@ -432,7 +433,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
   }
 
   void _showCancelDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).pageDriveDetailCancelDialogTitle),

--- a/lib/rides/models/ride.dart
+++ b/lib/rides/models/ride.dart
@@ -74,24 +74,24 @@ class Ride extends Trip {
   @override
   factory Ride.fromJson(Map<String, dynamic> json) {
     return Ride(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      start: json['start'],
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      start: json['start'] as String,
       startPosition: Position.fromDynamicValues(json['start_lat'], json['start_lng']),
-      startTime: DateTime.parse(json['start_time']),
-      end: json['end'],
+      startTime: DateTime.parse(json['start_time'] as String),
+      end: json['end'] as String,
       endPosition: Position.fromDynamicValues(json['end_lat'], json['end_lng']),
-      endTime: DateTime.parse(json['end_time']),
-      seats: json['seats'],
+      endTime: DateTime.parse(json['end_time'] as String),
+      seats: json['seats'] as int,
       price: parseHelper.parseDouble(json['price']),
-      status: RideStatus.values[json['status']],
-      hideInListView: json['hide_in_list_view'],
-      riderId: json['rider_id'],
-      rider: json.containsKey('rider') ? Profile.fromJson(json['rider']) : null,
-      driveId: json['drive_id'],
-      drive: json.containsKey('drive') ? Drive.fromJson(json['drive']) : null,
-      chatId: json['chat_id'],
-      chat: json.containsKey('chat') ? Chat.fromJson(json['chat']) : null,
+      status: RideStatus.values[json['status'] as int],
+      hideInListView: json['hide_in_list_view'] as bool,
+      riderId: json['rider_id'] as int,
+      rider: json.containsKey('rider') ? Profile.fromJson(json['rider'] as Map<String, dynamic>) : null,
+      driveId: json['drive_id'] as int,
+      drive: json.containsKey('drive') ? Drive.fromJson(json['drive'] as Map<String, dynamic>) : null,
+      chatId: json['chat_id'] as int?,
+      chat: json.containsKey('chat') ? Chat.fromJson(json['chat'] as Map<String, dynamic>) : null,
     );
   }
 
@@ -122,9 +122,8 @@ class Ride extends Trip {
   }
 
   static Future<bool> userHasRideAtTimeRange(DateTimeRange range, int userId) async {
-    final List<Map<String, dynamic>> jsonList = parseHelper.parseListOfMaps(
-      await supabaseManager.supabaseClient.from('rides').select().eq('rider_id', userId),
-    );
+    final List<Map<String, dynamic>> jsonList =
+        await supabaseManager.supabaseClient.from('rides').select<List<Map<String, dynamic>>>().eq('rider_id', userId);
     final List<Ride> rides =
         Ride.fromJsonList(jsonList).where((Ride ride) => ride.status.isApproved() && !ride.isFinished).toList();
 

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -77,14 +77,20 @@ class _RideDetailPageState extends State<RideDetailPage> {
     if (_ride?.status == RideStatus.preview) {
       ride = _ride!;
 
-      final Map<String, dynamic> data =
-          await supabaseManager.supabaseClient.from('drives').select(_driveQuery).eq('id', ride.driveId).single();
+      final Map<String, dynamic> data = await supabaseManager.supabaseClient
+          .from('drives')
+          .select<Map<String, dynamic>>(_driveQuery)
+          .eq('id', ride.driveId)
+          .single();
 
       ride.drive = Drive.fromJson(data);
     } else {
       final int id = _ride?.id ?? widget.id!;
-      final Map<String, dynamic> data =
-          await supabaseManager.supabaseClient.from('rides').select(_rideQuery).eq('id', id).single();
+      final Map<String, dynamic> data = await supabaseManager.supabaseClient
+          .from('rides')
+          .select<Map<String, dynamic>>(_rideQuery)
+          .eq('id', id)
+          .single();
       ride = Ride.fromJson(data);
     }
 
@@ -251,7 +257,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   }
 
   void _showCancelDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).pageRideDetailCancelDialogTitle),
@@ -287,7 +293,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   }
 
   void _showRequestDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageRideDetailRequestDialogTitle),
@@ -318,7 +324,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   }
 
   void _showHideDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageRideDetailButtonHide),
@@ -347,15 +353,18 @@ class _RideDetailPageState extends State<RideDetailPage> {
     ride.status = RideStatus.pending;
 
     // chat gets created by trigger, somehow it does not get returned immediately by the insert
-    final Map<String, dynamic> idHash =
-        await supabaseManager.supabaseClient.from('rides').insert(ride.toJson()).select().single();
+    final Map<String, dynamic> idHash = await supabaseManager.supabaseClient
+        .from('rides')
+        .insert(ride.toJson())
+        .select<Map<String, dynamic>>()
+        .single();
 
     ride = ride.copyWith(id: idHash['id'] as int);
     await loadRide();
   }
 
   void _showWithdrawDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).pageRideDetailWithdrawDialogTitle),
@@ -391,7 +400,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
   }
 
   void _showLoginDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).pageRideDetailLoginDialogTitle),

--- a/lib/rides/pages/search_ride_page.dart
+++ b/lib/rides/pages/search_ride_page.dart
@@ -6,7 +6,6 @@ import '../../drives/models/drive.dart';
 import '../../util/buttons/labeled_checkbox.dart';
 import '../../util/fields/increment_field.dart';
 import '../../util/locale_manager.dart';
-import '../../util/parse_helper.dart';
 import '../../util/search/address_suggestion.dart';
 import '../../util/search/start_destination_timeline.dart';
 import '../../util/supabase_manager.dart';
@@ -107,16 +106,15 @@ class _SearchRidePageState extends State<SearchRidePage> {
   Future<void> loadRides() async {
     if (_startSuggestion == null || _destinationSuggestion == null) return;
     setState(() => _loading = true);
-    final List<Map<String, dynamic>> data = parseHelper.parseListOfMaps(
-      await supabaseManager.supabaseClient.from('drives').select('''
+    final List<Map<String, dynamic>> data =
+        await supabaseManager.supabaseClient.from('drives').select<List<Map<String, dynamic>>>('''
           *,
           driver:driver_id (
             *,
             profile_features (*),
             reviews_received: reviews!reviews_receiver_id_fkey(*)
           )
-        ''').eq('start', _startController.text).eq('cancelled', false),
-    );
+        ''').eq('start', _startController.text).eq('cancelled', false);
     final List<Drive> drives = data.map((Map<String, dynamic> drive) => Drive.fromJson(drive)).toList();
     final List<Ride> rides = drives
         .map(

--- a/lib/rides/widgets/search_ride_filter.dart
+++ b/lib/rides/widgets/search_ride_filter.dart
@@ -232,7 +232,7 @@ class SearchRideFilter {
   }
 
   void dialog(BuildContext context, void Function(void Function()) setState) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => ScaffoldMessenger(
         child: StatefulBuilder(

--- a/lib/util/buttons/button.dart
+++ b/lib/util/buttons/button.dart
@@ -7,7 +7,7 @@ class Button extends StatelessWidget {
   final DisplayColorKind displayColorKind;
   final Color? backgroundColor;
   final Color? textColor;
-  final Function()? onPressed;
+  final VoidCallback? onPressed;
   final ButtonKind kind;
 
   const Button(
@@ -20,7 +20,7 @@ class Button extends StatelessWidget {
     this.kind = ButtonKind.big,
   });
 
-  factory Button.error(String text, {Function()? onPressed, Key? key}) {
+  factory Button.error(String text, {VoidCallback? onPressed, Key? key}) {
     return Button(
       text,
       onPressed: onPressed,
@@ -37,7 +37,7 @@ class Button extends StatelessWidget {
     );
   }
 
-  factory Button.submit(String text, {Function()? onPressed}) {
+  factory Button.submit(String text, {VoidCallback? onPressed}) {
     return Button(
       text,
       onPressed: onPressed,

--- a/lib/util/chat/models/chat.dart
+++ b/lib/util/chat/models/chat.dart
@@ -19,9 +19,9 @@ class Chat extends Model {
   @override
   factory Chat.fromJson(Map<String, dynamic> json) {
     return Chat(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      ride: json.containsKey('ride') ? Ride.fromJson(json['ride']) : null,
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      ride: json.containsKey('ride') ? Ride.fromJson(json['ride'] as Map<String, dynamic>) : null,
       messages:
           json.containsKey('messages') ? Message.fromJsonList(parseHelper.parseListOfMaps(json['messages'])) : null,
     );

--- a/lib/util/chat/models/message.dart
+++ b/lib/util/chat/models/message.dart
@@ -28,14 +28,14 @@ class Message extends Model {
   @override
   factory Message.fromJson(Map<String, dynamic> json) {
     return Message(
-      id: json['id'],
-      createdAt: DateTime.parse(json['created_at']),
-      chatId: json['chat_id'],
-      senderId: json['sender_id'],
-      content: json['content'],
-      read: json['read'],
-      chat: json.containsKey('chat') ? Chat.fromJson(json['chat']) : null,
-      sender: json.containsKey('sender') ? Profile.fromJson(json['sender']) : null,
+      id: json['id'] as int,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      chatId: json['chat_id'] as int,
+      senderId: json['sender_id'] as int,
+      content: json['content'] as String,
+      read: json['read'] as bool,
+      chat: json.containsKey('chat') ? Chat.fromJson(json['chat'] as Map<String, dynamic>) : null,
+      sender: json.containsKey('sender') ? Profile.fromJson(json['sender'] as Map<String, dynamic>) : null,
     );
   }
 

--- a/lib/util/profiles/profile_widget.dart
+++ b/lib/util/profiles/profile_widget.dart
@@ -11,8 +11,8 @@ class ProfileWidget extends StatelessWidget {
   final bool showDescription;
   final Widget? actionWidget;
   final bool isTappable;
-  final Function()? onTap;
-  final Function(dynamic)? onPop;
+  final VoidCallback? onTap;
+  final void Function(dynamic)? onPop;
   final bool withHero;
 
   const ProfileWidget(

--- a/lib/util/profiles/reviews/custom_rating_bar.dart
+++ b/lib/util/profiles/reviews/custom_rating_bar.dart
@@ -6,7 +6,7 @@ import 'custom_rating_bar_size.dart';
 
 class CustomRatingBar extends StatelessWidget {
   final CustomRatingBarSize size;
-  final Function(double) onRatingUpdate;
+  final void Function(double) onRatingUpdate;
   final int? rating;
 
   const CustomRatingBar({

--- a/lib/util/search/address_search_delegate.dart
+++ b/lib/util/search/address_search_delegate.dart
@@ -52,7 +52,7 @@ class AddressSearchDelegate extends SearchDelegate<AddressSuggestion?> {
   @override
   Widget buildSuggestions(BuildContext context) {
     return StatefulBuilder(
-      builder: (BuildContext context, Function(VoidCallback) setState) {
+      builder: (BuildContext context, void Function(VoidCallback) setState) {
         return FutureBuilder<List<AddressSuggestion>>(
           future: addressSuggestionManager.getSuggestions(query),
           builder: (BuildContext context, AsyncSnapshot<List<AddressSuggestion>> snapshot) {

--- a/lib/util/search/address_suggestion.dart
+++ b/lib/util/search/address_suggestion.dart
@@ -25,13 +25,13 @@ class AddressSuggestion {
   });
 
   factory AddressSuggestion.fromMotisAddressResponse(Map<String, dynamic> json) {
-    final String name = json['name'];
+    final String name = json['name'] as String;
     const AddressSuggestionType type = AddressSuggestionType.place;
 
-    final Map<String, dynamic> posJson = json['pos'];
+    final Map<String, dynamic> posJson = json['pos'] as Map<String, dynamic>;
     final Position pos = Position.fromDynamicValues(posJson['lat'], posJson['lng']);
 
-    final List<Map<String, dynamic>> regions = List<Map<String, dynamic>>.from(json['regions']);
+    final List<Map<String, dynamic>> regions = List<Map<String, dynamic>>.from(json['regions'] as List<dynamic>);
     final String postalCode = _extractFromRegions(regions, <int>[13]);
     final String city = _extractFromRegions(regions, <int>[8, 7, 6, 5, 4]);
     final String country = _extractFromRegions(regions, <int>[2]);
@@ -48,10 +48,10 @@ class AddressSuggestion {
   }
 
   factory AddressSuggestion.fromMotisStationResponse(Map<String, dynamic> json) {
-    final String name = json['name'];
+    final String name = json['name'] as String;
     const AddressSuggestionType type = AddressSuggestionType.station;
 
-    final Map<String, dynamic> posJson = json['pos'];
+    final Map<String, dynamic> posJson = json['pos'] as Map<String, dynamic>;
     final Position pos = Position.fromDynamicValues(posJson['lat'], posJson['lng']);
 
     return AddressSuggestion(
@@ -73,7 +73,9 @@ class AddressSuggestion {
   static String _extractFromRegions(List<Map<String, dynamic>> regions, List<int> adminLevels) {
     for (final int adminLevel in adminLevels) {
       try {
-        return regions.firstWhere((Map<String, dynamic> region) => region['admin_level'] == adminLevel)['name'];
+        final Map<String, dynamic> matchedRegion =
+            regions.firstWhere((Map<String, dynamic> region) => region['admin_level'] == adminLevel);
+        return matchedRegion['name'] as String;
       } catch (e) {
         continue;
       }
@@ -83,14 +85,14 @@ class AddressSuggestion {
 
   factory AddressSuggestion.fromJson(Map<String, dynamic> json, {bool fromHistory = false}) {
     return AddressSuggestion(
-      name: json['name'],
-      position: Position.fromJson(json['position']),
+      name: json['name'] as String,
+      position: Position.fromJson(json['position'] as Map<String, dynamic>),
       type: AddressSuggestionType.values.firstWhere((AddressSuggestionType e) => e.name == json['type']),
-      postalCode: json['postal_code'],
-      city: json['city'],
-      country: json['country'],
+      postalCode: json['postal_code'] as String,
+      city: json['city'] as String,
+      country: json['country'] as String,
       fromHistory: fromHistory,
-      lastUsed: json['last_used'] != null ? DateTime.parse(json['last_used']) : DateTime.now(),
+      lastUsed: json['last_used'] != null ? DateTime.parse(json['last_used'] as String) : DateTime.now(),
     );
   }
 

--- a/lib/util/search/address_suggestion_manager.dart
+++ b/lib/util/search/address_suggestion_manager.dart
@@ -48,7 +48,8 @@ class AddressSuggestionManager {
   Future<void> loadHistorySuggestions() async {
     final List<String> data = await storageManager.readData<List<String>>(getStorageKey()) ?? <String>[];
 
-    final Iterable<Map<String, dynamic>> suggestions = data.map((String suggestion) => jsonDecode(suggestion));
+    final Iterable<Map<String, dynamic>> suggestions =
+        data.map((String suggestion) => jsonDecode(suggestion) as Map<String, dynamic>);
     _historySuggestions = suggestions
         .map((Map<String, dynamic> suggestion) => AddressSuggestion.fromJson(suggestion, fromHistory: true))
         .toList();
@@ -131,7 +132,7 @@ class AddressSuggestionManager {
     final String response =
         await request.close().then((HttpClientResponse value) => value.transform(utf8.decoder).join());
 
-    final Map<String, dynamic> responseMap = json.decode(response);
+    final Map<String, dynamic> responseMap = json.decode(response) as Map<String, dynamic>;
 
     final List<Map<String, dynamic>> guesses =
         pick(responseMap, 'content', 'guesses').asListOrEmpty((RequiredPick p0) => p0.value as Map<String, dynamic>);

--- a/lib/util/search/position.dart
+++ b/lib/util/search/position.dart
@@ -7,7 +7,7 @@ class Position {
   Position(this.lat, this.lng);
 
   factory Position.fromJson(Map<String, dynamic> json) {
-    return Position(json['lat'], json['lng']);
+    return Position.fromDynamicValues(json['lat'], json['lng']);
   }
 
   factory Position.fromDynamicValues(dynamic lat, dynamic lng) {

--- a/lib/util/trip/drive_card.dart
+++ b/lib/util/trip/drive_card.dart
@@ -39,7 +39,8 @@ class _DriveCardState extends TripCardState<Drive, DriveCard> {
   }
 
   Future<void> loadDrive() async {
-    final Map<String, dynamic> data = await supabaseManager.supabaseClient.from('drives').select('''
+    final Map<String, dynamic> data =
+        await supabaseManager.supabaseClient.from('drives').select<Map<String, dynamic>>('''
       *,
       rides(
         *,

--- a/lib/util/trip/pending_ride_card.dart
+++ b/lib/util/trip/pending_ride_card.dart
@@ -11,7 +11,7 @@ import '../supabase_manager.dart';
 import 'trip_card.dart';
 
 class PendingRideCard extends TripCard<Ride> {
-  final Function() reloadPage;
+  final VoidCallback reloadPage;
   final Drive drive;
   const PendingRideCard(super.trip, {super.key, required this.reloadPage, required this.drive});
 
@@ -109,7 +109,7 @@ class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
   }
 
   void showApproveDialog(BuildContext context) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(S.of(context).cardPendingRideApproveDialogTitle),
@@ -151,7 +151,7 @@ class _PendingRideCardState extends TripCardState<Ride, PendingRideCard> {
   }
 
   void showRejectDialog(BuildContext context) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
         title: Text(S.of(context).cardPendingRideRejectDialogTitle),

--- a/lib/util/trip/ride_card.dart
+++ b/lib/util/trip/ride_card.dart
@@ -65,8 +65,11 @@ class _RideCardState extends TripCardState<Ride, RideCard> {
 
   Future<void> loadRide() async {
     Ride trip = widget.trip;
-    final Map<String, dynamic> data =
-        await supabaseManager.supabaseClient.from('drives').select(_driveQuery).eq('id', trip.driveId).single();
+    final Map<String, dynamic> data = await supabaseManager.supabaseClient
+        .from('drives')
+        .select<Map<String, dynamic>>(_driveQuery)
+        .eq('id', trip.driveId)
+        .single();
     trip.drive = Drive.fromJson(data);
     if (mounted) {
       setState(() {

--- a/lib/util/trip/trip_page_builder.dart
+++ b/lib/util/trip/trip_page_builder.dart
@@ -8,7 +8,7 @@ import 'trip_stream_builder.dart';
 
 class TripPageBuilder<T extends Trip> extends StatelessWidget {
   final Stream<List<T>> trips;
-  final Function() onFabPressed;
+  final VoidCallback onFabPressed;
 
   const TripPageBuilder(this.trips, {super.key, required this.onFabPressed});
 

--- a/lib/welcome/pages/reset_password_page.dart
+++ b/lib/welcome/pages/reset_password_page.dart
@@ -8,7 +8,7 @@ import '../../util/fields/password_field.dart';
 import '../../util/supabase_manager.dart';
 
 class ResetPasswordPage extends StatefulWidget {
-  final Function() onPasswordReset;
+  final VoidCallback onPasswordReset;
 
   const ResetPasswordPage({super.key, required this.onPasswordReset});
 
@@ -36,7 +36,7 @@ class ResetPasswordPageState extends State<ResetPasswordPage> {
 }
 
 class ResetPasswordForm extends StatefulWidget {
-  final Function() onPasswordReset;
+  final VoidCallback onPasswordReset;
 
   const ResetPasswordForm({super.key, required this.onPasswordReset});
 

--- a/test/analysis_options.yaml
+++ b/test/analysis_options.yaml
@@ -1,5 +1,11 @@
 include: ../analysis_options.yaml
 
+analyzer:
+  language:
+    strict-casts: false
+    strict-inference: false
+    strict-raw-types: false
+
 linter:
   rules:
     always_specify_types: false


### PR DESCRIPTION
This enables the strictest type checks that dart has to offer. It concerns mainly the `fromJson` methods where we need to cast the values before applying them.

Also, the `select` method needs to be cast to the right return type (depending on whether there is a `.single()`:  List<Map<String,dynamic>> or just Map<String, dynamic>).