### PR TITLE
Fix order of waypoints in DriveDetailPage

### DIFF
--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -131,7 +131,14 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
         }
       }
 
-      stops.sort((Waypoint a, Waypoint b) => a.time.compareTo(b.time));
+      stops.sort((Waypoint a, Waypoint b) {
+        final int timeDiff = a.time.compareTo(b.time);
+        if (timeDiff != 0) return timeDiff;
+        if (a.place == drive.start || b.place == drive.end) return -1;
+        if (a.place == drive.end || b.place == drive.start) return 1;
+
+        return 0;
+      });
       for (final Waypoint stop in stops) {
         stop.actions.sort((WaypointAction a, WaypointAction b) => a.isStart ? 1 : -1);
       }

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -164,6 +164,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                     padding: const EdgeInsets.all(8.0),
                     width: double.infinity,
                     child: Column(
+                      key: const Key('waypointCard'),
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: buildCard(stop),
@@ -294,7 +295,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
     );
   }
 
-  List<Widget> buildCard(Waypoint stop) {
+  List<Widget> buildCard(Waypoint waypoint) {
     final List<Widget> list = <Widget>[];
     list.add(
       MergeSemantics(
@@ -304,13 +305,13 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               Text(
-                localeManager.formatTime(stop.time),
+                localeManager.formatTime(waypoint.time),
                 style: Theme.of(context).textTheme.labelLarge!.copyWith(fontWeight: FontWeight.w700),
               ),
               const SizedBox(width: 4.0),
-              Text(stop.place),
-              if (stop.place == _drive!.start) Semantics(label: S.of(context).pageDriveDetailLabelStartDrive),
-              if (stop.place == _drive!.end) Semantics(label: S.of(context).pageDriveDetailLabelEndDrive),
+              Text(waypoint.place),
+              if (waypoint.place == _drive!.start) Semantics(label: S.of(context).pageDriveDetailLabelStartDrive),
+              if (waypoint.place == _drive!.end) Semantics(label: S.of(context).pageDriveDetailLabelEndDrive),
             ],
           ),
         ),
@@ -319,9 +320,9 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
 
     final Icon startIcon = Icon(Icons.north_east_rounded, color: Theme.of(context).own().success);
     final Icon endIcon = Icon(Icons.south_west_rounded, color: Theme.of(context).colorScheme.error);
-    final int actionsLength = stop.actions.length;
+    final int actionsLength = waypoint.actions.length;
     for (int index = 0; index < actionsLength; index++) {
-      final WaypointAction action = stop.actions[index];
+      final WaypointAction action = waypoint.actions[index];
       final Icon icon = action.isStart ? startIcon : endIcon;
       final Profile profile = action.ride.rider!;
       final Widget container = Semantics(


### PR DESCRIPTION
Before, it could happen that the end of the whole drive was placed before another Waypoint (of course only if the time is the same, which should probably not happen in reality - but it happened all the time with our fake data).