### PR TITLE
Fix SVG warnings

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -7,61 +6,11 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="91.303017mm"
-   height="91.303017mm"
+   width="91.303017"
+   height="91.303017"
    viewBox="0 0 91.303017 91.303016"
    version="1.1"
-   id="svg8"
-   inkscape:version="0.92.4 (f8dce91, 2019-08-02)"
-   sodipodi:docname="motis1.svg"
-   inkscape:export-filename="/home/felix/Downloads/motis1.svg.png"
-   inkscape:export-xdpi="142.43559"
-   inkscape:export-ydpi="142.43559">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="22.4"
-     inkscape:cx="112.52511"
-     inkscape:cy="260.2403"
-     inkscape:document-units="mm"
-     inkscape:current-layer="svg8"
-     showgrid="false"
-     inkscape:snap-others="false"
-     inkscape:snap-object-midpoints="true"
-     inkscape:snap-grids="true"
-     inkscape:snap-to-guides="false"
-     inkscape:snap-page="true"
-     inkscape:snap-text-baseline="true"
-     inkscape:snap-center="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+   id="svg8">
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"


### PR DESCRIPTION
Just cleaning up the SVG file a little bit to fix all the warnings that flutter always preduces when it shows that picture:
1) It does not know "mm" as a unit, so I just removed that (that should be pixels now, but it does not matter because we resize it anyways)
2) All the Inkscape autogenerated stuff cannot be parsed by flutter, so I just removed it.