### PR TITLE
Tappable editable row

### DIFF
--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -119,7 +119,7 @@ class _ProfilePageState extends State<ProfilePage> {
     final Widget description = _profile!.description?.isNotEmpty ?? false
         ? Text(
             _profile!.description!,
-            style: Theme.of(context).textTheme.bodyLarge,
+            style: Theme.of(context).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.normal),
           )
         : buildNoInfoText(S.of(context).pageProfileDescriptionEmpty);
     return EditableRow(

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -87,6 +87,7 @@ class _ProfilePageState extends State<ProfilePage> {
           Expanded(child: Container()),
           InkWell(
             onTap: () => _pushEditPage(EditUsernamePage(_profile!)),
+            key: const Key('editUsernameText'),
             child: username,
           ),
           Expanded(
@@ -96,7 +97,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 tooltip: S.of(context).edit,
                 icon: const Icon(Icons.edit),
                 onPressed: () => _pushEditPage(EditUsernamePage(_profile!)),
-                key: const Key('editUsername'),
+                key: const Key('editUsernameIcon'),
               ),
             ),
           ),

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -86,7 +86,7 @@ class _ProfilePageState extends State<ProfilePage> {
         children: <Widget>[
           Expanded(child: Container()),
           InkWell(
-            onTap: () => _pushAndLoadProfile(EditUsernamePage(_profile!)),
+            onTap: () => _pushEditPage(EditUsernamePage(_profile!)),
             child: username,
           ),
           Expanded(
@@ -95,7 +95,7 @@ class _ProfilePageState extends State<ProfilePage> {
               child: IconButton(
                 tooltip: S.of(context).edit,
                 icon: const Icon(Icons.edit),
-                onPressed: () => _pushAndLoadProfile(EditUsernamePage(_profile!)),
+                onPressed: () => _pushEditPage(EditUsernamePage(_profile!)),
                 key: const Key('editUsername'),
               ),
             ),
@@ -125,7 +125,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileDescriptionTitle,
       innerWidget: description,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () => _pushAndLoadProfile(EditDescriptionPage(_profile!)),
+      onPressed: () => _pushEditPage(EditDescriptionPage(_profile!)),
       key: const Key('description'),
     );
   }
@@ -141,7 +141,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileFullNameTitle,
       innerWidget: fullName,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () => _pushAndLoadProfile(EditFullNamePage(_profile!)),
+      onPressed: () => _pushEditPage(EditFullNamePage(_profile!)),
       key: const Key('fullName'),
     );
   }
@@ -157,7 +157,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileAgeTitle,
       innerWidget: age,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () => _pushAndLoadProfile(EditBirthDatePage(_profile!)),
+      onPressed: () => _pushEditPage(EditBirthDatePage(_profile!)),
       key: const Key('age'),
     );
   }
@@ -174,7 +174,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileGenderTitle,
       innerWidget: gender,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () => _pushAndLoadProfile(EditGenderPage(_profile!)),
+      onPressed: () => _pushEditPage(EditGenderPage(_profile!)),
       key: const Key('gender'),
     );
   }
@@ -187,7 +187,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileFeaturesTitle,
       innerWidget: features,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () => _pushAndLoadProfile(EditProfileFeaturesPage(_profile!)),
+      onPressed: () => _pushEditPage(EditProfileFeaturesPage(_profile!)),
       key: const Key('features'),
     );
   }
@@ -321,7 +321,7 @@ class _ProfilePageState extends State<ProfilePage> {
     );
   }
 
-  Future<void> _pushAndLoadProfile(Widget page) async {
+  Future<void> _pushEditPage(Widget page) async {
     await Navigator.of(context)
         .push(MaterialPageRoute<void>(builder: (BuildContext context) => page))
         .then((_) => loadProfile());

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -85,18 +85,17 @@ class _ProfilePageState extends State<ProfilePage> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Expanded(child: Container()),
-          username,
+          InkWell(
+            onTap: () => _pushAndLoadProfile(EditUsernamePage(_profile!)),
+            child: username,
+          ),
           Expanded(
             child: Align(
               alignment: Alignment.centerLeft,
               child: IconButton(
                 tooltip: S.of(context).edit,
                 icon: const Icon(Icons.edit),
-                onPressed: () {
-                  Navigator.of(context)
-                      .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditUsernamePage(_profile!)))
-                      .then((_) => loadProfile());
-                },
+                onPressed: () => _pushAndLoadProfile(EditUsernamePage(_profile!)),
                 key: const Key('editUsername'),
               ),
             ),
@@ -126,11 +125,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileDescriptionTitle,
       innerWidget: description,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () {
-        Navigator.of(context)
-            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditDescriptionPage(_profile!)))
-            .then((_) => loadProfile());
-      },
+      onPressed: () => _pushAndLoadProfile(EditDescriptionPage(_profile!)),
       key: const Key('description'),
     );
   }
@@ -146,11 +141,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileFullNameTitle,
       innerWidget: fullName,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () {
-        Navigator.of(context)
-            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditFullNamePage(_profile!)))
-            .then((_) => loadProfile());
-      },
+      onPressed: () => _pushAndLoadProfile(EditFullNamePage(_profile!)),
       key: const Key('fullName'),
     );
   }
@@ -166,11 +157,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileAgeTitle,
       innerWidget: age,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () {
-        Navigator.of(context)
-            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditBirthDatePage(_profile!)))
-            .then((_) => loadProfile());
-      },
+      onPressed: () => _pushAndLoadProfile(EditBirthDatePage(_profile!)),
       key: const Key('age'),
     );
   }
@@ -187,11 +174,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileGenderTitle,
       innerWidget: gender,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () {
-        Navigator.of(context)
-            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditGenderPage(_profile!)))
-            .then((_) => loadProfile());
-      },
+      onPressed: () => _pushAndLoadProfile(EditGenderPage(_profile!)),
       key: const Key('gender'),
     );
   }
@@ -204,11 +187,7 @@ class _ProfilePageState extends State<ProfilePage> {
       title: S.of(context).pageProfileFeaturesTitle,
       innerWidget: features,
       isEditable: _profile!.isCurrentUser,
-      onPressed: () {
-        Navigator.of(context)
-            .push(MaterialPageRoute<void>(builder: (BuildContext context) => EditProfileFeaturesPage(_profile!)))
-            .then((_) => loadProfile());
-      },
+      onPressed: () => _pushAndLoadProfile(EditProfileFeaturesPage(_profile!)),
       key: const Key('features'),
     );
   }
@@ -340,6 +319,12 @@ class _ProfilePageState extends State<ProfilePage> {
               ),
             ),
     );
+  }
+
+  Future<void> _pushAndLoadProfile(Widget page) async {
+    await Navigator.of(context)
+        .push(MaterialPageRoute<void>(builder: (BuildContext context) => page))
+        .then((_) => loadProfile());
   }
 
   Future<void> _updateProfilePictureDialog() async {

--- a/lib/account/pages/profile_page.dart
+++ b/lib/account/pages/profile_page.dart
@@ -119,7 +119,7 @@ class _ProfilePageState extends State<ProfilePage> {
     final Widget description = _profile!.description?.isNotEmpty ?? false
         ? Text(
             _profile!.description!,
-            style: Theme.of(context).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.normal),
+            style: Theme.of(context).textTheme.titleMedium,
           )
         : buildNoInfoText(S.of(context).pageProfileDescriptionEmpty);
     return EditableRow(

--- a/lib/account/widgets/editable_row.dart
+++ b/lib/account/widgets/editable_row.dart
@@ -17,6 +17,30 @@ class EditableRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget row = Row(
+      children: <Widget>[
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        if (isEditable)
+          const Expanded(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: Icon(Icons.edit),
+            ),
+          ),
+      ],
+    );
+    if (isEditable) {
+      row = Semantics(
+        tooltip: S.of(context).edit,
+        child: InkWell(
+          onTap: onPressed,
+          child: row,
+        ),
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[

--- a/lib/account/widgets/editable_row.dart
+++ b/lib/account/widgets/editable_row.dart
@@ -17,31 +17,44 @@ class EditableRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget row = Padding(
-      padding: const EdgeInsets.fromLTRB(0, 8, 6, 8),
-      child: Row(
-        children: <Widget>[
-          Text(
-            title,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          if (isEditable)
-            const Expanded(
-              child: Align(
-                alignment: Alignment.centerRight,
-                child: Icon(Icons.edit),
-              ),
-            ),
-        ],
-      ),
+    Widget titleWidget = Text(
+      title,
+      style: Theme.of(context).textTheme.titleLarge,
     );
     if (isEditable) {
-      row = Semantics(
+      titleWidget = Semantics(
         tooltip: S.of(context).edit,
         child: InkWell(
           onTap: onPressed,
-          key: const Key('editableRowButton'),
-          child: row,
+          key: const Key('editableRowTitleButton'),
+          child: titleWidget,
+        ),
+      );
+    }
+    final Widget row = Row(
+      children: <Widget>[
+        titleWidget,
+        if (isEditable)
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                icon: const Icon(Icons.edit),
+                key: const Key('editableRowIconButton'),
+                onPressed: onPressed,
+              ),
+            ),
+          ),
+      ],
+    );
+    Widget editableInner = innerWidget;
+    if (isEditable) {
+      editableInner = Semantics(
+        label: S.of(context).edit,
+        child: InkWell(
+          onTap: onPressed,
+          key: const Key('editableRowInnerButton'),
+          child: innerWidget,
         ),
       );
     }
@@ -49,7 +62,7 @@ class EditableRow extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         row,
-        innerWidget,
+        editableInner,
       ],
     );
   }

--- a/lib/account/widgets/editable_row.dart
+++ b/lib/account/widgets/editable_row.dart
@@ -40,7 +40,7 @@ class EditableRow extends StatelessWidget {
         tooltip: S.of(context).edit,
         child: InkWell(
           onTap: onPressed,
-          key: const Key('editButton'),
+          key: const Key('editableRowButton'),
           child: row,
         ),
       );

--- a/lib/account/widgets/editable_row.dart
+++ b/lib/account/widgets/editable_row.dart
@@ -17,26 +17,30 @@ class EditableRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget row = Row(
-      children: <Widget>[
-        Text(
-          title,
-          style: Theme.of(context).textTheme.titleLarge,
-        ),
-        if (isEditable)
-          const Expanded(
-            child: Align(
-              alignment: Alignment.centerRight,
-              child: Icon(Icons.edit),
-            ),
+    Widget row = Padding(
+      padding: const EdgeInsets.fromLTRB(0, 8, 6, 8),
+      child: Row(
+        children: <Widget>[
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
-      ],
+          if (isEditable)
+            const Expanded(
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Icon(Icons.edit),
+              ),
+            ),
+        ],
+      ),
     );
     if (isEditable) {
       row = Semantics(
         tooltip: S.of(context).edit,
         child: InkWell(
           onTap: onPressed,
+          key: const Key('editButton'),
           child: row,
         ),
       );
@@ -44,26 +48,7 @@ class EditableRow extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Row(
-          children: <Widget>[
-            Text(
-              title,
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            if (isEditable)
-              Expanded(
-                child: Align(
-                  alignment: Alignment.centerRight,
-                  child: IconButton(
-                    tooltip: S.of(context).edit,
-                    icon: const Icon(Icons.edit),
-                    onPressed: onPressed,
-                    key: const Key('editButton'),
-                  ),
-                ),
-              ),
-          ],
-        ),
+        row,
         innerWidget,
       ],
     );

--- a/test/widgets/profile/edit_birth_date_page_test.dart
+++ b/test/widgets/profile/edit_birth_date_page_test.dart
@@ -106,7 +106,7 @@ void main() {
       expect(find.text(profile.age.toString()), findsOneWidget);
 
       await tester
-          .tap(find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editButton'))));
+          .tap(find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditBirthDatePage), findsOneWidget);
 

--- a/test/widgets/profile/edit_birth_date_page_test.dart
+++ b/test/widgets/profile/edit_birth_date_page_test.dart
@@ -105,8 +105,8 @@ void main() {
       await tester.pump();
       expect(find.text(profile.age.toString()), findsOneWidget);
 
-      await tester
-          .tap(find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editableRowButton'))));
+      await tester.tap(
+          find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditBirthDatePage), findsOneWidget);
 

--- a/test/widgets/profile/edit_description_page_test.dart
+++ b/test/widgets/profile/edit_description_page_test.dart
@@ -82,8 +82,8 @@ void main() {
 
       expect(find.text(profile.description!), findsOneWidget);
 
-      await tester.tap(
-          find.descendant(of: find.byKey(const Key('description')), matching: find.byKey(const Key('editButton'))));
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('description')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditDescriptionPage), findsOneWidget);
 

--- a/test/widgets/profile/edit_description_page_test.dart
+++ b/test/widgets/profile/edit_description_page_test.dart
@@ -83,7 +83,7 @@ void main() {
       expect(find.text(profile.description!), findsOneWidget);
 
       await tester.tap(find.descendant(
-          of: find.byKey(const Key('description')), matching: find.byKey(const Key('editableRowButton'))));
+          of: find.byKey(const Key('description')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditDescriptionPage), findsOneWidget);
 

--- a/test/widgets/profile/edit_full_name_page_test.dart
+++ b/test/widgets/profile/edit_full_name_page_test.dart
@@ -103,8 +103,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester
-          .tap(find.descendant(of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editButton'))));
+      await tester.tap(
+          find.descendant(of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditFullNamePage), findsOneWidget);
 

--- a/test/widgets/profile/edit_full_name_page_test.dart
+++ b/test/widgets/profile/edit_full_name_page_test.dart
@@ -103,8 +103,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester.tap(
-          find.descendant(of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowButton'))));
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditFullNamePage), findsOneWidget);
 

--- a/test/widgets/profile/edit_gender_page_test.dart
+++ b/test/widgets/profile/edit_gender_page_test.dart
@@ -75,7 +75,8 @@ void main() {
         await pumpMaterial(tester, ProfilePage.fromProfile(profile));
         await tester.pump();
         await tester.tap(
-          find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowButton'))),
+          find.descendant(
+              of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowIconButton'))),
         );
         await tester.pumpAndSettle();
         expect(find.byType(EditGenderPage), findsOneWidget);
@@ -112,7 +113,8 @@ void main() {
         await pumpMaterial(tester, ProfilePage.fromProfile(profile));
         await tester.pump();
         await tester.tap(
-          find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowButton'))),
+          find.descendant(
+              of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowIconButton'))),
         );
         await tester.pumpAndSettle();
         expect(find.byType(EditGenderPage), findsOneWidget);

--- a/test/widgets/profile/edit_gender_page_test.dart
+++ b/test/widgets/profile/edit_gender_page_test.dart
@@ -74,8 +74,9 @@ void main() {
       testWidgets('Switching to a gender', (WidgetTester tester) async {
         await pumpMaterial(tester, ProfilePage.fromProfile(profile));
         await tester.pump();
-        await tester
-            .tap(find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editButton'))));
+        await tester.tap(
+          find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowButton'))),
+        );
         await tester.pumpAndSettle();
         expect(find.byType(EditGenderPage), findsOneWidget);
 
@@ -110,8 +111,9 @@ void main() {
 
         await pumpMaterial(tester, ProfilePage.fromProfile(profile));
         await tester.pump();
-        await tester
-            .tap(find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editButton'))));
+        await tester.tap(
+          find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowButton'))),
+        );
         await tester.pumpAndSettle();
         expect(find.byType(EditGenderPage), findsOneWidget);
 

--- a/test/widgets/profile/edit_profile_features_page_test.dart
+++ b/test/widgets/profile/edit_profile_features_page_test.dart
@@ -296,8 +296,8 @@ void main() {
 
       await tester.scrollUntilVisible(find.byKey(const Key('features')), 100,
           scrollable: find.byType(Scrollable).first);
-      await tester.tap(
-          find.descendant(of: find.byKey(const Key('features')), matching: find.byKey(const Key('editableRowButton'))));
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('features')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditProfileFeaturesPage), findsOneWidget);
 

--- a/test/widgets/profile/edit_profile_features_page_test.dart
+++ b/test/widgets/profile/edit_profile_features_page_test.dart
@@ -296,8 +296,8 @@ void main() {
 
       await tester.scrollUntilVisible(find.byKey(const Key('features')), 100,
           scrollable: find.byType(Scrollable).first);
-      await tester
-          .tap(find.descendant(of: find.byKey(const Key('features')), matching: find.byKey(const Key('editButton'))));
+      await tester.tap(
+          find.descendant(of: find.byKey(const Key('features')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
       expect(find.byType(EditProfileFeaturesPage), findsOneWidget);
 

--- a/test/widgets/profile/edit_username_page_test.dart
+++ b/test/widgets/profile/edit_username_page_test.dart
@@ -81,7 +81,7 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester.tap(find.byKey(const Key('editUsername')));
+      await tester.tap(find.byKey(const Key('editUsernameIcon')));
       await tester.pumpAndSettle();
       expect(find.byType(EditUsernamePage), findsOneWidget);
 

--- a/test/widgets/profile/profile_page_test.dart
+++ b/test/widgets/profile/profile_page_test.dart
@@ -248,7 +248,9 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      expect(find.byKey(const Key('editableRowButton')), findsNothing);
+      expect(find.byKey(const Key('editableRowIconButton')), findsNothing);
+      expect(find.byKey(const Key('editableRowTitleButton')), findsNothing);
+      expect(find.byKey(const Key('editableRowInnerButton')), findsNothing);
       expect(find.byKey(const Key('editUsernameIcon')), findsNothing);
       expect(find.byKey(const Key('editUsernameText')), findsNothing);
       expect(find.byKey(const Key('avatarUpload')), findsNothing);
@@ -259,7 +261,9 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      expect(find.byKey(const Key('editableRowButton')), findsNWidgets(5));
+      expect(find.byKey(const Key('editableRowIconButton')), findsNWidgets(5));
+      expect(find.byKey(const Key('editableRowTitleButton')), findsNWidgets(5));
+      expect(find.byKey(const Key('editableRowInnerButton')), findsNWidgets(5));
       expect(find.byKey(const Key('editUsernameIcon')), findsOneWidget);
       expect(find.byKey(const Key('editUsernameText')), findsOneWidget);
       expect(find.byKey(const Key('avatarUpload')), findsOneWidget);
@@ -347,8 +351,26 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester.tap(
-          find.descendant(of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowButton'))));
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowIconButton'))));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EditFullNamePage), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pump();
+
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowTitleButton'))));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EditFullNamePage), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pump();
+
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowInnerButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditFullNamePage), findsOneWidget);
@@ -359,7 +381,7 @@ void main() {
       await tester.pump();
 
       await tester.tap(find.descendant(
-          of: find.byKey(const Key('description')), matching: find.byKey(const Key('editableRowButton'))));
+          of: find.byKey(const Key('description')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditDescriptionPage), findsOneWidget);
@@ -369,8 +391,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester
-          .tap(find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editableRowButton'))));
+      await tester.tap(
+          find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditBirthDatePage), findsOneWidget);
@@ -380,8 +402,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester.tap(
-          find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowButton'))));
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowIconButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditGenderPage), findsOneWidget);
@@ -391,8 +413,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      final Finder editFeaturesButton =
-          find.descendant(of: find.byKey(const Key('features')), matching: find.byKey(const Key('editableRowButton')));
+      final Finder editFeaturesButton = find.descendant(
+          of: find.byKey(const Key('features')), matching: find.byKey(const Key('editableRowIconButton')));
       await tester.scrollUntilVisible(editFeaturesButton, 100, scrollable: find.byType(Scrollable).first);
       await tester.tap(editFeaturesButton);
       await tester.pumpAndSettle();

--- a/test/widgets/profile/profile_page_test.dart
+++ b/test/widgets/profile/profile_page_test.dart
@@ -248,8 +248,9 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      expect(find.byKey(const Key('editButton')), findsNothing);
-      expect(find.byKey(const Key('editUsername')), findsNothing);
+      expect(find.byKey(const Key('editableRowButton')), findsNothing);
+      expect(find.byKey(const Key('editUsernameIcon')), findsNothing);
+      expect(find.byKey(const Key('editUsernameText')), findsNothing);
       expect(find.byKey(const Key('avatarUpload')), findsNothing);
       expect(find.byKey(const Key('signOutButton')), findsNothing);
     });
@@ -258,8 +259,9 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      expect(find.byKey(const Key('editButton')), findsNWidgets(5));
-      expect(find.byKey(const Key('editUsername')), findsOneWidget);
+      expect(find.byKey(const Key('editableRowButton')), findsNWidgets(5));
+      expect(find.byKey(const Key('editUsernameIcon')), findsOneWidget);
+      expect(find.byKey(const Key('editUsernameText')), findsOneWidget);
       expect(find.byKey(const Key('avatarUpload')), findsOneWidget);
       expect(find.byKey(const Key('signOutButton')), findsOneWidget);
       expect(find.byKey(const Key('reportButton')), findsNothing);
@@ -327,7 +329,15 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester.tap(find.byKey(const Key('editUsername')));
+      await tester.tap(find.byKey(const Key('editUsernameIcon')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EditUsernamePage), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('editUsernameText')));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditUsernamePage), findsOneWidget);
@@ -337,8 +347,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester
-          .tap(find.descendant(of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editButton'))));
+      await tester.tap(
+          find.descendant(of: find.byKey(const Key('fullName')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditFullNamePage), findsOneWidget);
@@ -348,8 +358,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester.tap(
-          find.descendant(of: find.byKey(const Key('description')), matching: find.byKey(const Key('editButton'))));
+      await tester.tap(find.descendant(
+          of: find.byKey(const Key('description')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditDescriptionPage), findsOneWidget);
@@ -360,7 +370,7 @@ void main() {
       await tester.pump();
 
       await tester
-          .tap(find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editButton'))));
+          .tap(find.descendant(of: find.byKey(const Key('age')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditBirthDatePage), findsOneWidget);
@@ -370,8 +380,8 @@ void main() {
       await pumpMaterial(tester, ProfilePage.fromProfile(profile));
       await tester.pump();
 
-      await tester
-          .tap(find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editButton'))));
+      await tester.tap(
+          find.descendant(of: find.byKey(const Key('gender')), matching: find.byKey(const Key('editableRowButton'))));
       await tester.pumpAndSettle();
 
       expect(find.byType(EditGenderPage), findsOneWidget);
@@ -382,7 +392,7 @@ void main() {
       await tester.pump();
 
       final Finder editFeaturesButton =
-          find.descendant(of: find.byKey(const Key('features')), matching: find.byKey(const Key('editButton')));
+          find.descendant(of: find.byKey(const Key('features')), matching: find.byKey(const Key('editableRowButton')));
       await tester.scrollUntilVisible(editFeaturesButton, 100, scrollable: find.byType(Scrollable).first);
       await tester.tap(editFeaturesButton);
       await tester.pumpAndSettle();


### PR DESCRIPTION
As suggested in the user study, where almost everyone expected the respective category titles to be tappable. I'm not quite sure yet if really the whole row should be tappable or if we should keep the icon buttons and just make the text clickable as well (like for the username). Feedback appreciated!
@Showcas This could have a slight impact on your tests.