### PR TITLE
Redesign drive detail page

### DIFF
--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -155,7 +155,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
             return Padding(
               padding: const EdgeInsets.only(left: 8.0),
               child: Column(
-                children: <Widget>[const SizedBox(height: 5), buildCard(stop), const SizedBox(height: 5)],
+                children: <Widget>[Padding(padding: const EdgeInsets.symmetric(vertical: 5), child: buildCard(stop))],
               ),
             );
           },

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -179,12 +179,13 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
           itemCount: stops.length,
         ),
       );
-      widgets.add(timeline);
-
       if (approvedRides.isNotEmpty) {
+        widgets.add(timeline);
+
         widgets.add(const Divider(thickness: 1));
         final Set<Profile> riders = approvedRides.map((Ride ride) => ride.rider!).toSet();
         widgets.add(ProfileWrapList(riders, title: S.of(context).riders));
+        widgets.add(const Divider(thickness: 1));
       }
 
       final List<Ride> pendingRides = _drive!.pendingRides!.toList();

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -174,7 +174,6 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
           timeline,
           const Divider(),
           ProfileWrapList(riders, title: S.of(context).riders),
-          const Divider(),
         ]);
       }
 

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -155,24 +155,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
             return Padding(
               padding: const EdgeInsets.only(left: 8.0),
               child: Column(
-                children: <Widget>[
-                  const SizedBox(height: 10.0),
-                  Container(
-                    decoration: BoxDecoration(
-                      border: Border.all(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
-                      borderRadius: BorderRadius.circular(5.0),
-                    ),
-                    padding: const EdgeInsets.all(8.0),
-                    width: double.infinity,
-                    child: Column(
-                      key: const Key('waypointCard'),
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: buildCard(stop),
-                    ),
-                  ),
-                  const SizedBox(height: 10.0)
-                ],
+                children: <Widget>[const SizedBox(height: 5), buildCard(stop), const SizedBox(height: 5)],
               ),
             );
           },
@@ -180,12 +163,19 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
         ),
       );
       if (approvedRides.isNotEmpty) {
-        widgets.add(timeline);
-
-        widgets.add(const Divider(thickness: 1));
         final Set<Profile> riders = approvedRides.map((Ride ride) => ride.rider!).toSet();
-        widgets.add(ProfileWrapList(riders, title: S.of(context).riders));
-        widgets.add(const Divider(thickness: 1));
+        widgets.addAll(<Widget>[
+          const SizedBox(height: 5),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(S.of(context).pageDriveDetailRoute, style: Theme.of(context).textTheme.titleLarge),
+          ),
+          const SizedBox(height: 10),
+          timeline,
+          const Divider(),
+          ProfileWrapList(riders, title: S.of(context).riders),
+          const Divider(),
+        ]);
       }
 
       final List<Ride> pendingRides = _drive!.pendingRides!.toList();
@@ -297,9 +287,9 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
     );
   }
 
-  List<Widget> buildCard(Waypoint waypoint) {
-    final List<Widget> list = <Widget>[];
-    list.add(
+  Widget buildCard(Waypoint waypoint) {
+    final List<Widget> cardWidgets = <Widget>[];
+    cardWidgets.add(
       MergeSemantics(
         child: Padding(
           padding: const EdgeInsets.only(bottom: 4),
@@ -308,10 +298,10 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
             children: <Widget>[
               Text(
                 localeManager.formatTime(waypoint.time),
-                style: Theme.of(context).textTheme.labelLarge!.copyWith(fontWeight: FontWeight.w700),
+                style: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.normal),
               ),
-              const SizedBox(width: 4.0),
-              Flexible(child: Text(waypoint.place)),
+              const SizedBox(width: 6),
+              Flexible(child: Text(waypoint.place, style: Theme.of(context).textTheme.titleMedium)),
               if (waypoint.place == _drive!.start)
                 Semantics(label: S.of(context).pageDriveDetailLabelStartDrive)
               else if (waypoint.place == _drive!.end)
@@ -339,7 +329,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
         child: Container(
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
-            borderRadius: const BorderRadius.all(Radius.circular(5.0)),
+            borderRadius: const BorderRadius.all(Radius.circular(8)),
           ),
           child: Material(
             color: Colors.transparent,
@@ -355,7 +345,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
                 ),
               ).then((_) => loadDrive()),
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 10.0),
+                padding: const EdgeInsets.all(10),
                 child: Row(
                   children: <Widget>[
                     IconWidget(icon: icon, count: action.ride.seats),
@@ -382,14 +372,19 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
           ),
         ),
       );
-      list.add(container);
-
-      if (index < actionsLength - 1) {
-        list.add(const SizedBox(height: 6.0));
+      if (index < actionsLength) {
+        cardWidgets.add(const SizedBox(height: 6.0));
       }
+
+      cardWidgets.add(container);
     }
 
-    return list;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: SizedBox(width: double.infinity, child: Column(children: cardWidgets)),
+      ),
+    );
   }
 
   Future<void> hideDrive() async {

--- a/lib/drives/pages/drive_detail_page.dart
+++ b/lib/drives/pages/drive_detail_page.dart
@@ -380,6 +380,7 @@ class _DriveDetailPageState extends State<DriveDetailPage> {
     }
 
     return Card(
+      key: const Key('waypointCard'),
       child: Padding(
         padding: const EdgeInsets.all(10),
         child: SizedBox(width: double.infinity, child: Column(children: cardWidgets)),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -254,6 +254,7 @@
   "pageCreateDriveButtonCreate": "Erstellen",
 
   "pageDriveDetailTitle": "Fahrt Info",
+  "pageDriveDetailRoute": "Fahrtverlauf",
   "pageDriveDetailLabelStartDrive": "Start der Fahrt",
   "pageDriveDetailLabelEndDrive": "Ende der Fahrt",
   "pageDriveDetailLabelPickup": "{seats, plural, one{{user} abholen} other{{seats} Personen abholen, die mit {user} fahren}}",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -305,6 +305,7 @@
   "pageRidesTooltipSearchRide": "Fahrt suchen",
 
   "pageRideDetailTitle": "Mitfahrt Info",
+  "pageRideDetailDriver": "Fahrer*in",
   "pageRideDetailButtonRequest": "Mitfahrt anfragen",
   "pageRideDetailButtonCancel": "Mitfahrt absagen",
   "pageRideDetailButtonWithdraw": "Anfrage zurücknehmen",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -20,7 +20,7 @@
   "after": "Nachher",
   "failureSnackBar": "Es ist ein Fehler aufgetreten.",
 
-  "riders": "Mitfahrer",
+  "riders": "Mitfahrer*innen",
   "seats": "Plätze",
   "seatsCount": "{count, plural, one{1 Platz} other{{count} Plätze}}",
   "labelXOfYseats": "{seats} von {maxSeats} Plätzen",
@@ -177,7 +177,7 @@
   "pageHelpAnswer2": "Wir haben den Zahlungsprozess so konzipiert, dass er sich vollständig auf Benutzer*innenvereinbarungen stützt. Sowohl die Kosten als auch die Zahlungsmethode einer Fahrt können persönlich oder in unserem In-App-Chat ausgehandelt werden. Als Ausgangspunkt siehst du für die meisten Fahrten einen Preisvorschlag.",
   "pageHelpQuestion3": "Wir haben uns auf einen Preis geeinigt, aber jetzt zahlt mein*e Fahrer*in ihn nicht. Was kann ich machen?",
   "pageHelpAnswer3": "Wir entschuldigen uns für die Unannehmlichkeiten. Leider können wir dir in diesem Fall nur die Möglichkeit bieten, Benutzer*innen zu melden. Tippe in seinem*ihrem Profil auf die Schaltfläche \"{reportButtonText}\" und stelle sicher, dass du den Grund \"{didNotPayReasonText}\" auswählst.",
-  "pageHelpQuestion4": "Ein Fahrer/Mitfahrer ist nicht aufgetaucht. Was kann ich machen?",
+  "pageHelpQuestion4": "Ein*e Fahrer*in/Mitfahrer*in ist nicht aufgetaucht. Was kann ich machen?",
   "pageHelpAnswer4": "Wir entschuldigen uns für die Unannehmlichkeiten. Leider können wir dir in diesem Fall nur die Möglichkeit bieten, Benutzer*innen zu melden. Tippe in seinem*ihrem Profil auf die Schaltfläche \"{reportButtonText}\" und achte darauf, den Grund \"{didNotShowUpReasonText}\" auszuwählen.",
   "pageHelpQuestion5": "Meine Mitfahrt wurde abgesagt. Was kann ich machen?",
   "pageHelpAnswer5": "Wir entschuldigen uns für die Unannehmlichkeiten. Leider musst du dich nach einer anderen Fahrt umsehen. Wenn die*der Fahrer*in die Fahrt kurz vor der Fahrt abgesagt hat, kannst du sie*ihn über die Schaltfläche \"{reportButtonText}\" in ihrem*seinem Profil melden. Stelle sicher, dass du den Grund \"{differentReasonText}\" auswählst und die Situation erklärst.",
@@ -327,8 +327,8 @@
   "pageRideDetailHideDialog": "Bist du sicher, dass du die Mitfahrt löschen möchtest?",
 
   "pageDriveChatTitle": "Chats",
-  "pageDriveChatEmptyMessage": "Du kannst mit deinen Mitfahrern chatten, sobald du ihre Anfragen annimmst.",
-  "pageDriveChatRiderHeadline": "Mitfahrer",
+  "pageDriveChatEmptyMessage": "Du kannst mit deinen Mitfahrer*innen chatten, sobald du ihre Anfragen annimmst.",
+  "pageDriveChatRiderHeadline": "Mitfahrer*innen",
   "pageDriveChatRequestsHeadline": "Mitfahrtanfragen",
 
   "cardPendingRideApproveDialogTitle": "Mitfahrt annehmen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -254,6 +254,7 @@
   "pageCreateDriveButtonCreate": "Create",
 
   "pageDriveDetailTitle": "Drive Detail",
+  "pageDriveDetailRoute": "Route",
   "pageDriveDetailLabelStartDrive": "Start of drive",
   "pageDriveDetailLabelEndDrive": "End of drive",
   "pageDriveDetailLabelPickup": "{seats, plural, one{Pick up {user}} other{Pick up {seats} people associated with {user}}}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -304,6 +304,7 @@
   "pageRidesTooltipSearchRide": "Search ride",
 
   "pageRideDetailTitle": "Ride Detail",
+  "pageRideDetailDriver": "Driver",
   "pageRideDetailButtonRequest": "Request Ride",
   "pageRideDetailButtonCancel": "Cancel Ride",
   "pageRideDetailButtonWithdraw": "Withdraw request",

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -114,6 +114,7 @@ class _RideDetailPageState extends State<RideDetailPage> {
 
       final Profile driver = ride.drive!.driver!;
       widgets.addAll(<Widget>[
+        const SizedBox(height: 5),
         Align(
           alignment: Alignment.centerLeft,
           child: Text(S.of(context).pageRideDetailDriver, style: Theme.of(context).textTheme.titleLarge),

--- a/lib/rides/pages/ride_detail_page.dart
+++ b/lib/rides/pages/ride_detail_page.dart
@@ -113,13 +113,30 @@ class _RideDetailPageState extends State<RideDetailPage> {
       final Ride ride = _ride!;
 
       final Profile driver = ride.drive!.driver!;
-      widgets.add(ProfileWidget(driver, showDescription: true, withHero: true));
-      widgets.add(const Divider(thickness: 1));
-
-      widgets.add(ReviewsPreview(driver));
-
-      if (driver.profileFeatures!.isNotEmpty) widgets.add(const Divider(thickness: 1));
-      widgets.add(FeaturesColumn(driver.profileFeatures!));
+      widgets.addAll(<Widget>[
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Text(S.of(context).pageRideDetailDriver, style: Theme.of(context).textTheme.titleLarge),
+        ),
+        const SizedBox(height: 10),
+        ProfileWidget(driver, showDescription: true, withHero: true),
+        const SizedBox(height: 24),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Text(S.of(context).pageProfileReviewsTitle, style: Theme.of(context).textTheme.titleLarge),
+        ),
+        const SizedBox(height: 10),
+        ReviewsPreview(driver),
+        if (driver.profileFeatures!.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 24),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(S.of(context).pageProfileFeaturesTitle, style: Theme.of(context).textTheme.titleLarge),
+          ),
+          const SizedBox(height: 10),
+          FeaturesColumn(driver.profileFeatures!),
+        ],
+      ]);
 
       if (ride.status.isRealRider()) {
         widgets.add(const Divider(thickness: 1));

--- a/test/widgets/drive_detail_page_test.dart
+++ b/test/widgets/drive_detail_page_test.dart
@@ -45,10 +45,18 @@ void main() {
         // Wait for the drive to be fully loaded
         await tester.pump();
 
-        expect(find.text(drive.start), findsNWidgets(2));
+        expect(find.text(drive.start), findsOneWidget);
       });
 
       testWidgets('Works with object parameter', (WidgetTester tester) async {
+        drive = DriveFactory().generateFake(
+          start: 'Start',
+          end: 'End',
+          endTime: DateTime.now().add(const Duration(hours: 1)),
+          rides: [RideFactory().generateFake(status: RideStatus.approved)],
+        );
+        whenRequest(processor).thenReturnJson(drive.toJsonForApi());
+
         await pumpMaterial(tester, DriveDetailPage.fromDrive(drive));
 
         expect(find.byType(TripOverview), findsOneWidget);


### PR DESCRIPTION
Finally, a redesign of the drives detail page! I've never been a fan of the containers with a border, and thought it much more practical to use what I think Flutter intends for this use case: A card. I think this worked out quite well. Otherwise, I made a few changes to font sizes, spacing etc here and there.

It is worth mentioning that I included a few headers like "Driver" on the Ride Detail Page or "Route" on the Drive Detail Page. I think this looks better than Dividers. It is also a response to the user studies, where some users didn't get that the features belonged to the drivers, or why the start and destination information is displayed twice on the Drive Detail Page.