### PR TITLE
Fix username hint

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -72,7 +72,8 @@
 
   "pageRegisterTitle": "Registrieren",
   "pageRegisterUsername": "Nutzername",
-  "pageRegisterUsernameHint": "Wir empfehlen deinen Vornamen",
+  "pageRegisterUsernameHint": "Gib deinen Nutzernamen ein",
+  "pageRegisterUsernameHelper": "Wir empfehlen deinen Vornamen",
   "pageRegisterUsernameValidateEmpty": "Bitte gib deinen Nutzernamen ein",
   "pageRegisterButtonCreate": "Account erstellen",
   "pageRegisterButtonCreated": "Account erstellt",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -72,7 +72,8 @@
 
   "pageRegisterTitle": "Register",
   "pageRegisterUsername": "Username",
-  "pageRegisterUsernameHint": "We recommend you choose your real name",
+  "pageRegisterUsernameHint": "Enter your username",
+  "pageRegisterUsernameHelper": "We recommend you choose your real name",
   "pageRegisterUsernameValidateEmpty": "Please enter your username",
   "pageRegisterButtonCreate": "Create Account",
   "pageRegisterButtonCreated": "Account created",

--- a/lib/welcome/pages/register_page.dart
+++ b/lib/welcome/pages/register_page.dart
@@ -124,6 +124,8 @@ class RegisterFormState extends State<RegisterForm> {
                 border: const OutlineInputBorder(),
                 labelText: S.of(context).pageRegisterUsername,
                 hintText: S.of(context).pageRegisterUsernameHint,
+                helperText: S.of(context).pageRegisterUsernameHelper,
+                helperMaxLines: 2,
               ),
               key: const Key('registerUsernameField'),
               controller: usernameController,
@@ -134,7 +136,7 @@ class RegisterFormState extends State<RegisterForm> {
                 return null;
               },
             ),
-            const SizedBox(height: 15),
+            const SizedBox(height: 25),
             PasswordField(
               controller: passwordController,
               validateSecurity: true,


### PR DESCRIPTION
Just a very quick PR based on Felix' feedback that he was unable to see the whole hint text.
![Screenshot_20230302-163455](https://user-images.githubusercontent.com/63241108/222949382-adb9f9d2-9332-401e-9771-95f9878f351a.png)

The hint was very inconsistent anyways. So I moved that to the helper text below (does not take more space because there is already the 0/15 display because of the maximal length) and wrote a hint consistent to what we normally write. With that one, it does not matter if it is cut off because it is not vital information.

